### PR TITLE
Add WAMECU bias simulation prototype notebook

### DIFF
--- a/notebooks/WAMECU_prototype.ipynb
+++ b/notebooks/WAMECU_prototype.ipynb
@@ -1,0 +1,212 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6ca1aa57",
+   "metadata": {},
+   "source": [
+    "# WAMECU Bias Simulation Prototype\n",
+    "\n",
+    "This notebook provides a minimal simulation environment for exploring the WAMECU framework — an AI-assisted approach to quantifying bias in systems that are often treated as random. The notebook generates synthetic draws under controlled bias coefficients, illustrates how the WAMECU adjustment modifies baseline probabilities, and offers simple diagnostics for detecting and estimating bias."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf372d6",
+   "metadata": {},
+   "source": [
+    "## 1. Imports and Utilities\n",
+    "\n",
+    "The helper functions below implement the core WAMECU relationship. The `wamecu_probabilities` function converts a vector of bias coefficients into a probability distribution. Bias coefficients are expected to average to zero; however, the helper function defensively normalizes the distribution to account for rounding or exploratory inputs. The `simulate_draws` utility produces synthetic outcome data so the rest of the notebook can focus on analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4d46021a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import math\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "from typing import Iterable\n",
+    "\n",
+    "plt.style.use(\"seaborn-v0_8\")\n",
+    "\n",
+    "def wamecu_probabilities(n_outcomes: int, beta: Iterable[float]) -> np.ndarray:\n",
+    "    \"\"\"Compute WAMECU-adjusted probabilities.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    n_outcomes : int\n",
+    "        Number of equally likely baseline outcomes.\n",
+    "    beta : Iterable[float]\n",
+    "        Bias coefficients associated with each outcome.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    np.ndarray\n",
+    "        Normalized probability distribution incorporating bias.\n",
+    "    \"\"\"\n",
+    "    beta = np.asarray(list(beta), dtype=float)\n",
+    "    if beta.size != n_outcomes:\n",
+    "        raise ValueError(\"beta vector must match number of outcomes\")\n",
+    "\n",
+    "    base = np.full(n_outcomes, 1.0 / n_outcomes)\n",
+    "    adjusted = base * (1 + beta)\n",
+    "\n",
+    "    # Guard against negative probabilities from large negative beta values.\n",
+    "    if np.any(adjusted < 0):\n",
+    "        raise ValueError(\"bias coefficients yield negative probabilities\")\n",
+    "\n",
+    "    total = adjusted.sum()\n",
+    "    if not math.isclose(total, 1.0):\n",
+    "        adjusted = adjusted / total\n",
+    "    return adjusted\n",
+    "\n",
+    "\n",
+    "def simulate_draws(probabilities: np.ndarray, n_trials: int, seed: int | None = None) -> np.ndarray:\n",
+    "    \"\"\"Simulate draws from a categorical distribution.\"\"\"\n",
+    "    rng = np.random.default_rng(seed)\n",
+    "    support = np.arange(probabilities.size)\n",
+    "    return rng.choice(support, size=n_trials, p=probabilities)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "49aa29a2",
+   "metadata": {},
+   "source": [
+    "## 2. Define a Baseline Scenario\n",
+    "\n",
+    "Start with a six-outcome system (e.g., a standard die). The bias coefficients below emphasize outcome 0 (analogous to side **1** on a die) and depress outcome 5. The remaining values are kept small to emulate subtle mechanical or environmental drift."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "073073c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_outcomes = 6\n",
+    "beta = np.array([0.08, 0.02, -0.01, -0.02, 0.0, -0.07])\n",
+    "probabilities = wamecu_probabilities(n_outcomes, beta)\n",
+    "probabilities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1ff49f7",
+   "metadata": {},
+   "source": [
+    "The resulting distribution is close to the baseline 1/6 for each outcome but exhibits a measurable skew. Outcome 0 is favored, while outcome 5 is suppressed. The distribution is automatically renormalized so that the probabilities sum to 1."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0276a2c1",
+   "metadata": {},
+   "source": [
+    "## 3. Simulate Synthetic Draws\n",
+    "\n",
+    "Run a set of synthetic trials to observe how the bias manifests in data. A reproducible random seed is used for deterministic runs, making the notebook convenient for demos and unit tests."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c431b644",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_trials = 20_000\n",
+    "outcomes = simulate_draws(probabilities, n_trials, seed=42)\n",
+    "counts = pd.Series(outcomes).value_counts().sort_index()\n",
+    "counts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "012b407d",
+   "metadata": {},
+   "source": [
+    "## 4. Compare Observed and Expected Frequencies\n",
+    "\n",
+    "Visualize the empirical counts against the WAMECU-derived expectations. The chart highlights deviations that an analyst would investigate through anomaly detection or machine learning models within the broader framework."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea82134a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected_counts = probabilities * n_trials\n",
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "index = np.arange(n_outcomes)\n",
+    "ax.bar(index - 0.15, counts.values, width=0.3, label=\"Observed\", color=\"#4C72B0\")\n",
+    "ax.bar(index + 0.15, expected_counts, width=0.3, label=\"Expected\", color=\"#55A868\")\n",
+    "ax.set_xlabel(\"Outcome\")\n",
+    "ax.set_ylabel(\"Count\")\n",
+    "ax.set_title(\"Observed vs. Expected Counts under WAMECU Bias\")\n",
+    "ax.set_xticks(index)\n",
+    "ax.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1981c6f8",
+   "metadata": {},
+   "source": [
+    "## 5. Estimate Bias Coefficients from Data\n",
+    "\n",
+    "Given observed counts, we can produce a quick estimate of the implied bias coefficients. The estimator compares empirical frequencies against the baseline uniform probabilities. In practice, this step would be augmented with confidence intervals, regularization, and domain-specific constraints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5194b61d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "baseline_prob = np.full(n_outcomes, 1.0 / n_outcomes)\n",
+    "empirical_prob = counts.values / n_trials\n",
+    "# Avoid division by zero by masking low-frequency cases.\n",
+    "mask = baseline_prob > 0\n",
+    "estimated_beta = np.zeros_like(empirical_prob)\n",
+    "estimated_beta[mask] = (empirical_prob[mask] / baseline_prob[mask]) - 1\n",
+    "estimated_beta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c2486cc",
+   "metadata": {},
+   "source": [
+    "These estimated coefficients are noisy due to finite sampling but follow the same pattern as the ground truth. Analysts could feed these estimates into anomaly detection routines, simulation calibrations, or machine learning models — all pillars of the WAMECU workflow."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00c82162",
+   "metadata": {},
+   "source": [
+    "## 6. Next Steps\n",
+    "\n",
+    "* Add physics-driven or data-driven priors that constrain permissible bias coefficients.\n",
+    "* Integrate anomaly detection methods (e.g., Bayesian change-point detection) for streaming data.\n",
+    "* Train adaptive machine learning models on enriched metadata to predict real-time β dynamics.\n",
+    "* Wrap the notebook in a lightweight dashboard for stakeholder reporting."
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a WAMECU prototype notebook that demonstrates how bias coefficients adjust baseline probabilities
- include helper utilities, synthetic draws, visualization, and coefficient estimation steps to support the WAMECU framework

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d8843fb2dc8320a72969aba52dbcd9