### PR TITLE
Handle zero-mass bias configurations in WAMECU prototype

### DIFF
--- a/notebooks/WAMECU_prototype.ipynb
+++ b/notebooks/WAMECU_prototype.ipynb
@@ -62,6 +62,8 @@
     "        raise ValueError(\"bias coefficients yield negative probabilities\")\n",
     "\n",
     "    total = adjusted.sum()\n",
+    "    if total <= 0:\n",
+    "        raise ValueError(\"bias coefficients collapse the probability mass\")\n",
     "    if not math.isclose(total, 1.0):\n",
     "        adjusted = adjusted / total\n",
     "    return adjusted\n",


### PR DESCRIPTION
## Summary
- guard the `wamecu_probabilities` helper against bias inputs that eliminate all probability mass
- preserve the existing renormalization path for well-behaved experiments

## Abstract
This update hardens the WAMECU prototype by detecting bias coefficient combinations that collapse the adjusted probability mass. By throwing an explicit error before renormalization, analysts receive faster feedback when exploring extreme scenarios.

## Testing
- not run (numpy dependency unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68d889040df08320a61f2414aa152058