### PR TITLE
[WAMECU] Add anomaly detection utilities and tests

### DIFF
--- a/notebooks/WAMECU_anomaly_detection.ipynb
+++ b/notebooks/WAMECU_anomaly_detection.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6560a248",
+   "metadata": {},
+   "source": [
+    "# WAMECU Anomaly Detection Notebook\n",
+    "\n",
+    "This notebook extends the prototype simulation by applying statistical tests to synthetic draws. We examine how chi-square and entropy diagnostics react when bias is present in the WAMECU coefficients."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e1a3837d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:30.476725Z",
+     "iopub.status.busy": "2025-09-28T01:13:30.476392Z",
+     "iopub.status.idle": "2025-09-28T01:13:32.800024Z",
+     "shell.execute_reply": "2025-09-28T01:13:32.798662Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "plt.style.use(\"seaborn-v0_8\")\n",
+    "\n",
+    "project_root = Path().resolve()\n",
+    "for candidate in {project_root / \"src\", project_root.parent / \"src\"}:\n",
+    "    if candidate.exists() and str(candidate) not in sys.path:\n",
+    "        sys.path.append(str(candidate))\n",
+    "\n",
+    "from wamecu import (\n",
+    "    chi_square_statistic,\n",
+    "    entropy_gap,\n",
+    "    simulate_draws,\n",
+    "    wamecu_probabilities,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cc3e84a",
+   "metadata": {},
+   "source": [
+    "## 1. Generate Synthetic Draws\n",
+    "\n",
+    "We reuse the six-outcome system from the prototype. The bias vector amplifies the first outcome and suppresses the final outcome, mimicking a skewed die."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "500ce91c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:32.804730Z",
+     "iopub.status.busy": "2025-09-28T01:13:32.803977Z",
+     "iopub.status.idle": "2025-09-28T01:13:32.832578Z",
+     "shell.execute_reply": "2025-09-28T01:13:32.831661Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>observed</th>\n",
+       "      <th>expected</th>\n",
+       "      <th>deviation</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>3593</td>\n",
+       "      <td>3600.000000</td>\n",
+       "      <td>-7.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>3426</td>\n",
+       "      <td>3400.000000</td>\n",
+       "      <td>26.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3313</td>\n",
+       "      <td>3300.000000</td>\n",
+       "      <td>13.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3387</td>\n",
+       "      <td>3266.666667</td>\n",
+       "      <td>120.333333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>3230</td>\n",
+       "      <td>3333.333333</td>\n",
+       "      <td>-103.333333</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>3051</td>\n",
+       "      <td>3100.000000</td>\n",
+       "      <td>-49.000000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   observed     expected   deviation\n",
+       "0      3593  3600.000000   -7.000000\n",
+       "1      3426  3400.000000   26.000000\n",
+       "2      3313  3300.000000   13.000000\n",
+       "3      3387  3266.666667  120.333333\n",
+       "4      3230  3333.333333 -103.333333\n",
+       "5      3051  3100.000000  -49.000000"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "n_outcomes = 6\n",
+    "beta = np.array([0.08, 0.02, -0.01, -0.02, 0.0, -0.07])\n",
+    "probabilities = wamecu_probabilities(n_outcomes, beta)\n",
+    "n_trials = 20000\n",
+    "outcomes = simulate_draws(probabilities, n_trials, seed=123)\n",
+    "counts = pd.Series(outcomes).value_counts().sort_index().rename('observed')\n",
+    "expected = pd.Series(probabilities * n_trials, name='expected')\n",
+    "summary = pd.concat([counts, expected], axis=1)\n",
+    "summary['deviation'] = summary['observed'] - summary['expected']\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e93e634f",
+   "metadata": {},
+   "source": [
+    "## 2. Visualize the Bias\n",
+    "\n",
+    "The bar chart emphasizes where the empirical counts deviate from expectation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "32b70de3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:32.836252Z",
+     "iopub.status.busy": "2025-09-28T01:13:32.835961Z",
+     "iopub.status.idle": "2025-09-28T01:13:33.049877Z",
+     "shell.execute_reply": "2025-09-28T01:13:33.048827Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsEAAAGKCAYAAADtxpxGAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXGBJREFUeJzt3XlYVGX/x/E3q4AoouC+5oILKKCmKMYj7kupWEruZbmnpSZkppgK5qNmbrmk5r5lmbgvlWWuqYQa7kvuAooLLiDw+8Mf8ziCiutMzed1XV4y59xzzvfMPQOfuec+Z6zS0tLSEBERERGxINamLkBERERE5GVTCBYRERERi6MQLCIiIiIWRyFYRERERCyOQrCIiIiIWByFYBERERGxOArBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFnkOduzYgYeHBzt27MhS+/bt29O+ffsXVk9gYCChoaEvbPvy4pw5cwYPDw++//57U5ciPPlrW/459FoThWD5x/n+++/x8PB46L+oqChTlyiPEBgY+NC+69y5s6nLy7L58+ebxR/PuLg4vvjiCxo2bEilSpXw9vYmKCiIyZMnc+3aNVOXB0BkZCTffvutqcswa9HR0Xh4eGT6OHXv3h0PDw+WLVuWYV3btm2pVatWhuV9+vTBw8OD//73v5nuLz3ce3h48OOPP2baJjg4GA8PD5o2bWq0/ElfwzExMfTv35+AgAA8PT159dVX6dSpE8uWLSMlJQX4XyCdMWNGprXMmDEDDw8Pzpw5k+n6dBMmTDCqp2zZsvj7+9O1a1f9bZAMbE1dgMjT6t27N4ULF86wvGjRoi+9lqpVqxIdHY2dnV2W2j/sF72lKFeuHO+8806G5Xnz5jVBNU9n4cKFuLq6EhQUZLIaoqOj6dKlCzdv3uSNN96gQoUKAOzfv5/p06fzxx9/MHPmTJPVl27lypUcOXKETp06mboUs1W+fHkcHR3ZvXt3hsdp79692NrasmfPHlq2bGlYnpSUxL59+6hdu7ZR+xs3bvDzzz9TqFAhVq1aRf/+/bGyssp0v9myZWPlypU0a9bMaPmZM2fYu3cv2bJly/R+WX0NL126lCFDhpAnTx6aNWtGsWLFSExMZPv27Xz66afExsbSrVu3hz4uTyssLAwnJyfS0tI4f/48S5cupV27dixdupRy5coBUKhQIaKjo7G1VRSyVOp5+cd67bXX8PLyMnUZAFhbWz/0j8X9bt26haOjI/b29i+hKvOVL1++DH905clcu3aNXr16YWNjww8//EDJkiWN1n/00UcsWbLERNXJw9y8eRMnJ6cMy21tbalYsSJ79uwxWn78+HGuXLlC06ZN2b17t9G6AwcOcOfOHSpXrmy0fN26daSmphIeHk7Hjh3ZtWsXr776aqb1BAQE8NNPP3H58mVy585tWL5y5Urc3NwoVqxYpp8oZOU1HBUVxZAhQ/D29mbatGk4Ozsb1nXq1Il9+/Zx5MiRR27jaTVo0MDoeOrWrUvTpk1Zu3atIQRbWVll6fe2/HtpOoT8a93/8dr8+fOpU6cOlSpV4t133+X8+fOkpaUxadIkXnvtNSpWrEj37t1JSEgw2kZgYCBdu3Zly5YtNGvWDC8vLxo3bsz69euN2mU2b7B9+/Y0bdqU/fv307ZtWypVqsTYsWMN6x6cE3znzh0mTJhAgwYN8PLywt/fn169evH3338b2syYMYPg4GCqVatGxYoVCQoKYu3atU/82CQnJ/Pqq6/yySefZFh348YNvLy8+OKLLwzL5s6dS5MmTahUqRJVq1YlKCiIyMjIJ95vVsXHx1O9enXat29PWlqaYfmpU6fw9vbmww8/NCy7/3EODg6mYsWKBAYGsnDhwgzbTUpKYvz48dSrVw9PT08CAgIYNWoUSUlJGdr++OOPvPnmm4Zjbtu2LVu2bAHuPS+OHDnCzp07DR+73t+f165dY8SIEYaPf+vVq8e0adNITU012se1a9cIDQ2lcuXKVKlShZCQEK5fv56lx2jRokVcvHiR0NDQDAEYwM3NjR49ehgtmz9/Pk2aNMHT0xN/f3+GDh2aIeA8bD75g8/Z9Of86tWr+frrrw1vSjt27MipU6eM7vfLL79w9uxZw2MVGBhoWP80z630KVEPfjT+qNfh0aNHad++PZUqVaJWrVpMnz49w3YvXLhAjx498Pb2xs/Pj/Dw8EyfGwB//vknnTt3pnLlylSqVIl27dplCKnpH80fPXqUfv36UbVqVdq0afPQ46pcuTJxcXFGj9+ePXtwdnamdevWnDhxgsuXLxutS7/f/SIjI6lRowbVq1enZMmSj3w869Spg729fYbfIytXrqRRo0bY2Ng89L6PM3HiRKysrBg9erRRAE7n5eX10j5JcXNzAzA6nszmBB88eJDQ0FDq1KmDl5cXNWvW5JNPPuHKlStG27tx4wYjRowgMDAQT09P/Pz8eOeddzhw4MBLOR55PjQSLP9YN27cMPqDAPfe2bu6uhoti4yMJDk5mfbt25OQkMA333zDhx9+SPXq1dmxYwfvv/8+p06dYt68eXzxxRdEREQY3f/kyZN89NFHBAcH06JFC5YtW0afPn345ptvqFmz5iNrTEhI4P3336dJkya88cYb5MmTJ9N2KSkpdO3alW3bttGkSRM6dOhAYmIiv//+O4cPHzZM8ZgzZw6BgYG8/vrrJCcns2rVKvr06cPUqVP5z3/+k+XHzs7Ojrp167JhwwaGDh1qNDK9ceNGkpKSaNy4MQBLlixh+PDhNGjQgA4dOnDnzh0OHTrEn3/+yeuvv57lfd7v7t27GfoOwMnJCQcHB/LkyUNYWBh9+vRh7ty5dOjQgdTUVEJDQ8mePTtDhgwxut/Vq1fp0qULjRo1okmTJqxZs4awsDDs7Ox48803AUhNTaV79+7s3r2bVq1aUbJkSQ4fPszs2bM5efIkkydPNmxv4sSJTJgwAR8fH3r37o2dnR1//vkn27dvx9/fn4EDBzJs2DCcnJwMH+Wm/5G9desW7dq14+LFiwQHB1OgQAH27t3L2LFjiY2N5dNPPwUgLS2NHj16sHv3boKDgylZsiQbNmwgJCQkS4/hTz/9hIODAw0aNMhS+wkTJjBx4kRq1KjB22+/zYkTJ1i4cCH79u1j4cKFWZ7K86Dp06djZWXFu+++y40bN/jmm2/o378/S5cuBaBbt25cv36dCxcuGN50Zc+eHXgxz63MXL16lffee4969erRqFEj1q1bx+jRoylTpgwBAQEA3L59m44dO3L+/Hnat29P3rx5+fHHH9m+fXuG7W3bto33338fT09PevXqhZWVFd9//z0dO3ZkwYIFVKxY0ah9nz59KFasGB999JHRm7oHpYfZ3bt3U6xYMeBe0PX29qZSpUrY2dmxd+9e6tSpY1iXPXt2ypYta9jGxYsX2bFjByNHjgSgSZMmzJ49m88++yzTT6AcHBwIDAxk1apVhoB+8OBBjhw5wvDhwzl06FCmtT7uNXzr1i22b99OlSpVKFiw4EOP+UW5evUqcO91dvHiRSZPnky2bNlo1KjRI++3detWTp8+TVBQEO7u7hw5coQlS5Zw9OhRlixZYphWMmTIENatW0e7du0oWbIkCQkJ7N69m2PHjhmmJYn5UwiWf6zM5hfa29uzb98+o2UXL15k/fr15MiRA7gXhqZOncrt27dZtmyZYT7YlStXiIyMzBAKT548yYQJE6hfvz4Ab775Jg0bNmT06NGPDcGxsbEMHTqU4ODgR7Zbvnw527Zt45NPPjE6ri5duhj90Vy3bh0ODg6G223btiUoKIhZs2Y9UQgGaNy4McuWLeP33383mlO4evVqihQpYphq8ssvv1C6dGnGjx//RNt/lC1btuDn55dheb9+/ejSpQsADRs2pGnTpowdO5bXXnuNTZs2sWfPHiZNmpThjc6lS5cIDQ01zFFs3bo1rVq1YuzYsTRr1gw7OzsiIyPZunUrc+fOpUqVKob7li5dmiFDhrBnzx58fX05deoUkyZNol69eowfPx5r6/99YJbeF3Xr1mXcuHG4urpm+Eh41qxZnD59mh9++IHixYsD904wyps3LzNmzODdd9+lQIECbNq0iV27dvHxxx/z3nvvAfD222/ToUOHLD2Gx48fp3jx4lmaWnP58mWmTp2Kv78/06dPNxzTK6+8wueff86KFSuM5po+iTt37rB8+XJDHTlz5mTEiBEcPnyYMmXKULNmTebMmcO1a9cyPFYv4rmVmUuXLvHFF1/QvHlz4N5rODAwkGXLlhlC8OLFizl58iTjxo0zBKVWrVplqDktLY2wsDCqVavGN998YwhFwcHBNGnShHHjxmWYh122bFnGjBnz2Dq9vb2xsbFh9+7dhhHSPXv20LRpU7Jly0a5cuXYvXu3UQhOv0+6VatWYW9vb2jTpEkTxo8fz6+//krdunUz3e/rr79Ot27dOH/+PAUKFGDFihUUKVIEb2/vh9b6uNfwqVOnSE5OpkyZMo897hehYcOGRrdz5szJpEmTKF269CPv16ZNG959912jZd7e3vTt25fdu3cbfnds3ryZVq1aGX1q8v777z+n6uVlUQiWf6zBgwdTokQJo2X3B5Z0DRs2NARgwDBK88YbbxidEFGxYkVWrlzJxYsXKVKkiGF53rx5qVevnuG2s7MzzZs3Z/r06cTGxuLu7v7QGu3t7bP0cd/69etxdXWlXbt2Gdbdf0LL/QH46tWrpKSkULlyZVatWvXYfTyoevXquLq6snr1akMIvnr1Klu3bjX6I5AzZ04uXLhAdHR0hhGup1WpUiWjKQ3p0ke/0n322Wfs2LGD3r17c/LkSZo1a5bpH3JbW1tat25tuG1vb0/r1q0JCwvjwIEDeHt7s3btWkqWLMkrr7xiNIJVvXp14N5H6b6+vmzcuJHU1FR69uyZ4fn0sJOL7rd27VoqV65Mzpw5jfZTo0YNpk2bxq5du3jjjTf49ddfsbW15e233za0sbGxoV27dvzxxx+P3c+NGzcMI6qPs3XrVpKTk+nQoYPRMb311luMHTuWzZs3P3UIDgoKMgri6SHh9OnTjw1AL+K5lRknJyejMGtvb4+XlxenT582LPv1119xd3c3Ck+Ojo60atXK6AoLMTExnDx5ku7du2f4iNzPz48ff/yR1NRUo8f5cW+C0zk7O+Ph4WGYVnH58mVOnDiBr68vAL6+voYpEOlTI9LXpYuMjCQgIMAw/aB48eJUqFCBFStWPDQE16xZExcXF1atWkXnzp1ZvXr1Y+f7Pu41fOPGDYAsP0eftwkTJuDs7GwYCV64cCG9e/dmxowZGR6z+93/O/bOnTskJiZSqVIl4N4c7PTnd86cOfnzzz+5ePEi+fLle7EHIy+MQrD8Y1WsWDFLJ8YVKFDA6HZ6IH7Y8qtXrxqF4GLFimUIP+kjfGfPnn1kCM6XL1+WRur+/vtvSpQo8dizlH/++We+/vprYmJijOYqZiWcPcjW1pb69euzcuVKkpKSsLe3Z/369SQnJxumQsC90Y2tW7fy1ltvUaxYMWrWrEnTpk0zzEN8Eq6urtSoUeOx7XLlysWgQYPo06cPbm5uDBo0KNN2efPmzXCy0f195O3tzalTpzh27Fimo1dwbx4y3OsLa2vrTOfZZsWpU6c4dOjQQ/eTHozTnzsPhoQH39g9jLOzM4mJiVlqe+7cOeDeyO/97O3tKVKkCGfPns3SdjLz4EfdOXPmBMjS5dlexHMrM/nz58/wGnFxcTH6qP/s2bOZvtYf7I+TJ08CPHLayvXr13FxcTHczuwqNg9TuXJl5s6dy+XLl9m7dy82NjaGEObj48OCBQtISkrKdD7wsWPH+Ouvv2jWrJnRvOJq1aoxf/58bty4kencXDs7Oxo2bMjKlSupWLEi58+ff+x0lMe9htP3k9XnaFZl9XddlSpVjE6Ma9CgAQ0aNGD48OGPvLRhQkICEydOZPXq1YbfCenun6/fv39/QkND+c9//kOFChUICAigefPmRn87xPwpBMu/3sNO7Mhs1Bh45Jy9J3X/qMKz+uOPP+jevTtVq1ZlyJAhuLu7Y2dnx7Jly1i5cuVTbbNJkyYsXrzY8FHp2rVreeWVV4zmGJYsWZK1a9fyyy+/8Ntvv7F+/XoWLFhAz5496d279/M6vIdKPxnt6tWrXLhwwRCynlRqaiplypTJ9GRAuBeUnofU1FRq1qxpmOLwoPRw/qxeeeUVw5uhl3G1kZSUlExfS8/yOnra59bDgtCDJx6me5aTux6UflwDBgwwXGXgQQ++IXuSKxD4+voyd+5c9uzZw969eylTpozhjZKPjw9JSUlER0eze/dubG1tjaYsrFixAoCIiIgM5zbAvelUDxvxf/3111m0aBETJkygbNmylCpVKss1Z6ZYsWLY2tpy+PDhLLVPf4xu376d6fpbt24ZtXtS2bNnp2LFimzatOmhV+gA+PDDD9m7dy+dO3emXLlyODk5kZqaynvvvWf0nG7cuDFVqlRhw4YN/P7778yYMYPp06czYcIEwxQbMX8KwSKPcerUKdLS0oz+8KaPBhUqVOi57KNo0aL8+eefJCcnP/QEpXXr1pEtWzZmzJhhFHoyu4B+VlWtWhV3d3dWr16Nr68v27dvz/SanU5OTjRu3JjGjRuTlJTEBx98wJQpU+jatesLvcTQr7/+ytKlS3nvvfeIjIwkNDSUJUuWZBgxv3TpUoY/bA/2UdGiRTl48CB+fn6PHE0qWrQoqampHDt27KEhBx4exIoWLcrNmzcfO9JdqFAhtm/fTmJiotFo8IkTJx55v3S1a9dm7969rF+/PsOXGTwofbT2+PHjRiNVSUlJnDlzxqhWFxeXTEdxz50799SjXI96vJ/muZX+RujBK2k8y4h2oUKFOHz4cIbX+oP9kf4YODs7Z+nTjCd1/8lxUVFRRh/d58uXj0KFCrFnzx727NlDuXLlcHR0BO6F88jISKpVq5bpFSgmT55MZGTkQ0Nw5cqVKViwIDt37qR///7PfByOjo5Ur16d7du3G+YaP0ru3LlxdHR86PP/xIkTODo6Zjgf4EmkfzHHw0Lw1atX2bZtGx988AG9evUyLE//XfKgvHnz0rZtW9q2bUt8fDwtWrRgypQpCsH/ILpEmshjXLp0iQ0bNhhu37hxg+XLl1OuXLlHToV4EvXr1+fKlSvMnz8/w7r00QcbGxusrKwMv8jh3iV+Nm3a9NT7tba2pmHDhvz888+sWLGCu3fvGk2FADLMe7S3t6dkyZKkpaWRnJwM3BulOXbsWKZniz+ta9euMWjQICpWrEjfvn0ZPnw4Bw4cYMqUKRna3r17l8WLFxtuJyUlsXjxYnLnzm04U7tRo0ZcvHgx02vn3r59m5s3bwL3TnqztrZm0qRJGUYW7x8JcnR0zDQsNmrUiL179/Lbb79lekx3794F7l3n+u7du0aXcktJSWHevHmPfFzSBQcH4+7uzsiRIzMNDvHx8YYrXtSoUQM7Ozvmzp1rdAzfffcd169fN/qjXaRIEf7880+j6TY///wz58+fz1JdmXF0dMz00m9ZeW5lJv1qKbt27TIsS0lJeabrIr/22mtcunTJ6FJht27dyrBNT09PihYtysyZMzP9qP9ZXwP58uWjcOHCbN++nf379+Pj42O03sfHh02bNnHixAmjqRC7d+/m7NmzBAUF0bBhwwz/GjduzI4dO7h48WKm+7WysuLTTz+lV69ez+0a3j179iQtLY0BAwZk+ljt37+fH374Abj3+61mzZr8/PPPhuk76c6dO8fPP/9MzZo1n3pUPyEhgb179+Lu7v7Qq/Q8bNuzZ882up2SkpLh+ZwnTx7y5s370EvqiXnSSLD8Y/36668cP348w3JfX9/nOi+rePHifPrpp+zbt488efKwbNky4uPjM/248Wk1b96c5cuXExERQXR0NJUrV+bWrVts27aNt99+m7p16xIQEMCsWbN47733aNq0KfHx8SxYsICiRYs+9DJGWdGoUSPmzp3L+PHjKVOmTIa5sJ07d8bNzQ1fX1/y5MnD8ePHmTdvntHJN9HR0XTo0IFevXrxwQcfPHafFy9ezPSrWrNnz244eWfEiBEkJCQwa9YsbGxseO2113jrrbeYMmUKdevWNZqykTdvXqZPn87Zs2cpXrw4q1evJiYmhmHDhhlG1ps1a8aaNWsYMmSI4SS4lJQUjh8/ztq1a/nmm2/w8vKiWLFidOvWjcmTJ9OmTRvq169vuOpI3rx56devHwAVKlRg4cKFTJ48mWLFipE7d278/Pzo3LkzP/30E926daNFixZUqFCBW7ducfjwYdatW8emTZvInTs3gYGB+Pr6MmbMGM6ePUupUqVYv359lq8T7OLiwqRJk+jSpQvNmzc3+sa4v/76i5UrVxoCVO7cuenatSsTJ07kvffeIzAwkBMnTrBgwQK8vLx44403DNt96623WLduHe+99x6NGjXi77//JjIy8pm+ibFChQqsXr2aiIgIvLy8cHJyIjAwMEvPrcyULl0ab29vxo4dy9WrV3FxcWH16tWGNxhPo1WrVsyfP5+QkBAOHDiAu7s7P/74Y4YpTdbW1gwfPpz333+fpk2bEhQURL58+QyXJnN2ds70jdqTqFy5suH18eBJXD4+PobpT/eH4MjISGxsbB56lZjAwEC+/PJLVq9enek3vcG9N4APO3nuQVl5Dfv6+jJ48GCGDh1Ko0aNjL4xbufOnfz0009GJ9f17duXVq1a0aJFC1q3bk2hQoU4e/YsixcvxsrKir59+2apNrj3yVn6N8ZdunSJZcuWcfXqVYYOHfrQTyacnZ2pWrUq33zzDcnJyeTLl4/ff/89w/WoExMTCQgIoEGDBpQtWxYnJye2bt3Kvn37Mr3GtpgvhWD5x3rYZZUiIiKeewj+7LPPGDVqFCdOnKBw4cJ8+eWX1KpV67ntw8bGhunTp/P111+zcuVK1q9fT65cufD19cXDwwO4d+b5iBEjmD59OuHh4RQuXJj+/ftz9uzZZwrBvr6+FChQgPPnz2cYBYZ7lxuLjIxk1qxZ3Lx5k/z589O+ffsMX8TwJGJiYhgwYECG5YUKFaJu3bps2rSJ5cuXZ/giiNDQULZu3UpISAjfffedIeC6uLgwcuRIhg8fzpIlS3Bzc2Pw4MG0atXKcN/00d1vv/2WH3/8kQ0bNuDo6EjhwoVp37690QlQffr0oXDhwsybN48vv/wSR0dHPDw8jEbIevbsyblz5/jmm29ITEzk1Vdfxc/PD0dHR+bOncvUqVNZu3Yty5cvx9nZmeLFi/PBBx8YTsC0trbm66+/Jjw8nBUrVmBlZWX4oor0S3k9TqVKlYiMjGTGjBn88ssv/Pjjj1hbW/PKK6/QpUsXo6uNfPDBB+TOnZt58+YRERGBi4sLrVq1om/fvkZTcGrVqkVoaCizZs0iPDwcT09PpkyZYvTlKU+qTZs2xMTE8P333/Ptt99SqFAhAgMDn+m5NXr0aAYPHsy0adPImTMnb775JtWqVXtowHscR0dHvv32W4YNG8a8efNwcHDg9ddf57XXXsswv7tatWosXryYyZMnM2/ePG7evIm7uzsVK1Y0ukrJ00oPwenTH+53fyhOD8HJycmsXbsWHx8fcuXKlek2y5QpQ+HChVmxYsVTP0b3e9xrOF1wcDBeXl7MnDmT5cuXc+XKFZycnChfvjwRERFGb8BKlizJkiVLmDhxIt99953hDU7NmjXp2bPnE52sGhYWZvjZyckJDw8PPvzww8deJ3jMmDEMGzaMBQsWkJaWRs2aNZk+fbrR73sHBwfefvttfv/9d9avX09aWhpFixZlyJAhj/wyFDE/VmnP8ywgkX+ZwMBASpcuzdSpU01dijxE+/btuXLlylOfHCgiIpZJc4JFRERExOIoBIuIiIiIxVEIFhERERGLoznBIiIiImJxNBIsIiIiIhZHIVhERERELI5CsIiIiIhYHH1ZxhOIjc3aNzn901lbW5E7d3YuX04kNVVTxk1N/WF+1CfmR31iXtQf5seS+sTdPUeW2mkkWDKwtrbCysoKa+vMv1pSXi71h/lRn5gf9Yl5UX+YH/VJRgrBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4CsEiIiIiYnEUgkVERETE4igEi4iIiIjFUQgWERER+Yd7883XWbJkganLeG5exvHYvtCtyz9Wq8XdTbLfSYGjTLJfERGxPO+O/Oml7m9maOBT3e/ixQvMmDGVHTu2cfVqAnnyuFGr1n945533cHHJ9XyLtCAKwWbuZb9A0zm+apLdioiIyH3Onj1Dt27vUqRIUcLCRlCgQCFOnDjG5MlfsX37VqZNm0XOnC4vva6UlBSsrKywtv7nTir451YuIiIi8i83duwo7Ozs+PLLifj4VCZ//vz4+dVk3LjJxMVdYtq0yYa2N2/eZMiQgdSt60/z5o1YtmyJYV1aWhoTJkygWbPG1K7tR7NmDRk37r+G9UlJSUycOI7mzRtRt64/77/fkT17/jCsX706koYN/8OWLZtp1+4tAgNrEBm5nMDAGly/ft2o5nHjRtO7dzfD7T//jKJHj/cIDKxJUFATxo37L7du3TKsv3LlMgMGfERgYE3eeusN1q9f81wfw4dRCBYRERExQ9euXWXnzm20aPEm2bI5GK3Lk8eNevUasWnTBtLS0gBYsGAupUqVYebM+bRr15Hx48ewa9d2AH7+eRPffvstISGfsnDhD0REjOaVV0oZtvfll6M4cCCaoUPDmT17EbVr16V//96cPv23oc3t27eZP382ISGDmDt3MfXrN8LZOQebN28ytElJSeGnnzZQv35D4N5Idv/+H/Cf/wQye/ZChg4NJzo6ii+//N/0xxEjwrh06SLjx09h2LAv+OGHpVy5cvn5P6APUAgWERERMUOnT58mLS2NYsVKZLq+ePHiXL9+jYSEKwB4eVWifftOFC1ajDffDOY//wlk8eJ7J5dduHABNzc3Xn31VfLnz0/58p688UYLw7rVqyMZNuwLKlXyoVChwrRp0x4vL29Wr4407O/u3bv07RuKl1clihYtjqOjI3Xq1GfDhnWGNrt37+LGjesEBNQBYO7cWdSr15BWrdpQpEhRvLwq0afPx6xdu4o7d+7w99+n2L59KyEhn+Lp6UXZsuUIDR3MnTt3Xshjej+TzwlesGABCxcu5OzZswCULl2aHj16EBAQAED79u3ZuXOn0X1at27N559/brh97tw5wsLC2LFjB05OTjRv3px+/fpha/u/w9uxYwcjR47kyJEjFChQgO7duxMUFPQSjlBERETk6aWP9D6Op6eX0e0KFSqydOlCAOrUqcvSpQsJCnqDatX8qF69JjVr1sLW1pbjx4+SkpLC228b56KkpCRcXP4339jOzo5SpUobtalfvyFdu75DXFwsbm7urF+/Bj+/muTIkQOAo0ePcOzYETZsWGt0PKmpqZw/f47Tp09hY2ODh0c5w/pixYrj7JwjS8f8LEwegvPnz0///v0pVqwYaWlpLF++nJ49e/LDDz9QuvS9B7pVq1b07t3bcB9HR0fDzykpKXTt2hU3NzcWLVrEpUuXCAkJwc7Ojr59+wL33kl17dqV4OBgRo8ezbZt2xg0aBDu7u7UqlXr5R6wiIiISBYULlwYKysrTp06AdTOsP7kyZPkyJGTXLlcH7utfPnys3btWtav/4kdO7YzduxIFi6cy8SJ07h16yY2NjbMmDEXa2sbo/vdn7myZcuGlZWV0fpy5SpQsGBhNm5cR4sWb/Lrr7/w6adDDOtv3bpJs2ZBvPlmcKY1nT596rG1vygmD8GBgcaXC/noo49YuHAhUVFRhhDs4OCAu7t7pvffsmULR48eZdasWbi5uVGuXDn69OnD6NGj6dWrF/b29ixatIjChQsTGhoKQMmSJdm9ezfffvutQrCIiIiYJReXXFStWo0ffviO1q3bGM0Ljo+PY8OGNTRs2MQQTA8c2Gd0/wMH9lGsWHHDbQcHB2rVCsDPrxZBQW/Rps2bHDt2lNKlPUhJSeHKlStUquTzxHXWr9+Q9evX4u6eD2trK/z8/A3rypQpy4kTJyhcuEim9y1WrDgpKSkcOhRDuXIVAPj775PcuHE90/bPk8lD8P1SUlJYu3YtN2/exMfnf50QGRnJihUrcHd3p3bt2vTo0cPwziQqKooyZcrg5uZmaO/v709YWBhHjx6lfPnyREVF4efnZ7Qvf39/wsPDn6g+a2srrK2tHt9QnpqtraapP8jGxtrofzE99Yn5UZ+YF/VH5p7mb1z//qF06dKJfv0+oGvXHhQsWIjjx48xceJXuLvnpXv3Xobt7tsXzcKFcwgIqM3Ondv55ZdNjBnzFba21qxeHYm9vQ0lS5bF3t6eDRvWki2bA4ULF8TFJRcNGjRi+PAh9O79ER4eZbly5Qp//LGTUqVKU7NmLUP+yewYGjVqzMyZ05g7dya1a9fFyel/Yb1Dh068914nxo0bxRtvtMDBwZGTJ4+zc+d2+vcP5ZVXXqF69Rr8978RDBjwCba2Nnz55WiyZXPA2trqheYCswjBhw4dIjg4mDt37uDk5MSkSZMoVereGYtNmzalYMGC5M2bl0OHDjF69GhOnDjBxIkTAYiLizMKwIDhdmxs7CPb3Lhxg9u3b+PgYHzG5cPkzp09w8cA8ny5umY3dQlmK2dOx8c3kpdKfWJ+1Cfmxdz7I3JMM1OX8FiuruX4/vvvmTBhAp999glXr17Fzc2NunXr0rNnT1xd702FsLGx5t133+HIkcPMnDkdZ2dnQkNDadSoHgD58rkxbdo0jh07RmpqKmXKlGHq1CkUL14IgDFj/svXX3/NxInjuHTpErly5cLb25tGjerj6pqd7NnvTYXI7O+0q2s5KlasSHR0NJ99Nsiozauv+jBv3lzGjRtHt26dAShSpAiNGzc2tBs9ehSDBg2iR4/3cXNzo0+fPowfPx5HR/sXmgus0rI62/oFSkpK4vz581y/fp1169axdOlS5s2bZwjC99u2bRudOnViw4YNFC1alM8++4xz584xY8YMQ5tbt27h7e3NtGnTCAgIoEGDBgQFBdG1a1dDm82bN9OlSxf+/PPPLIfg+PgbL30kuMPwjS91f+kcX137+EYvwNT6o02yX3NmY2NNzpyOXLt2i5SUVFOXI6hPzJH6xLyoP8yPJfVJVoOzWYwE29vbU6xYMQA8PT3Zt28fc+bMMboCRLpKlSoBcOrUKYoWLYqbmxvR0dFGbeLi4gAM84jd3NwMy+5v4+zsnOUADJCamkZqqsnfM/yr3b37735hPouUlFQ9PmZGfWJ+1CfmRf1hftQn/2OWk3VSU1NJSkrKdF1MTAzwv4Dr7e3N4cOHiY+PN7TZunUrzs7OhpFkb29vtm/fbrSdrVu34u3t/QKqFxERERFzZ/IQPGbMGHbt2sWZM2c4dOgQY8aMYefOnbz++uv8/fffTJo0if3793PmzBk2bdpESEgIVatWpWzZssC9E9xKlSrFgAEDOHjwIL/99hvjxo2jbdu22NvbAxAcHMzp06cZNWoUx44dY/78+axZs4ZOnTqZ8MhFRERExFRMPh0iPj6ekJAQLl26RI4cOfDw8GDGjBnUrFmT8+fPs23bNubMmcPNmzcpUKAA9evXp0ePHob729jYMGXKFMLCwmjdujWOjo60aNHC6LrCRYoUYerUqURERDBnzhzy58/P8OHDdXk0EREREQtlFifG/VPExr74a9Y96N2RP730fYLpToybFDjq8Y1MyFT9ETmmGVeuJGoel5mwtbXG1TW7+sSMqE/Mi/rD/FhSn7i7Z+3b5kw+HUJERERE5GUz+XQIEXm8Vou7m2zf5j46LyIi8jQUgkVE5Lky5bQhEZGs0nQIEREREbE4GgkWERERi9TzpwEvdX+aXvZ4vXp1oXRpD/r06ffC96UQLCIiImKmRowIY82alRmWv/qqH2PHTjBBRRm9zOD6PCkEi4iIyHOnE3qfn2rVajBw4GCjZXZ29iaq5t9DIVhERETEjNnb25Enj1uG5Xv2/EHfvr346quvqVTJB4D582ezcOE85sxZRO7ceejVqwuvvFISa2sr1q5djY2NLc2bt+S997phZWUFQFJSEtOmTWbjxnXcuHGdEiVK0r37B/j6VjHsKzo6imnTJhMTcwA7O3vKl69AWFg4EyaMJSpqD1FRe1i6dCEAS5euoECBghw/fpRJk8YTHb0XBwdHXn21Gh980I9cuXIBcOvWLUaPjuDXX3/GycmJ4OD2L/iRNKYQLCL/aLoSgYhYKl/fKrRq9TbDhg3m228Xcu7cGb75ZgrDho0kd+48hnZr1qzijTeasXTpUnbs2M3IkcPJly8/b7zRAoAvvxzFyZPHGTo0HDc3dzZv/pn+/Xsze/YiihQpypEjh/jwwx40bvwGffr0x8bGhr17/yA1NZU+ffpz+vTflChRkvfe6wpArlyuXL9+nd69u/P6683p3bsvd+7c5uuvJzB4cCjjx08BYNKkr4iK2kNExBhcXXMzdeokDh8+ROnSHi/l8VMIFhF5Cqb6qPff9jGviDze1q1bqFevltGy9u3foUOHd3n//R7s2rWDUaNGcPz4MRo2bIq/f4BR23z58vHhh/3JndsZV9d8HDlyhCVLFvDGGy24cOECq1dHsmzZStzc3AFo06Y9O3ZsY/XqSLp27cn8+XPw8ChH//6hhm2+8kpJw8+2trY4ODgYjVYvW7aYMmU86Nq1p2HZJ58MJiioCX//fQo3N3dWrfqRzz4bRpUqrwIwaFAYLVo0fn4P3GMoBIuIiIiYMR+fyvTv/4nRspw5cwJgZ2fH4MHD6dTpbfLly0/v3n0z3L98eU/D1AcAT08vFi2aR0pKCsePHyUlJYW33w4yuk9SUhIuLi4AHD16mNq16z5RzUePHmHPnj8yhHeAs2fPcOfOHZKTkylf3vO+Y3KhaNFiT7SfZ6EQLCIiImLGHB0dKVy4yEPX798fDcC1a9e4du0qjo6OWd72rVs3sbGxYcaMuVhb22TYL4C9fbYnrvnWrVvUrFmL7t17Z1iXJ48bZ86cfuJtPm8KwSIi8q+gKSpiic6ePcP48WMZMOBTNm3awIgRYYwbNxlr6/99H9pffx0wus+BA/spUqQoNjY2lC7tQUpKCleuXDGcXPegUqVK88cfO+ncuWum6+3s7EhNTTFaVqaMB5s3/0T+/AWwtc0YNwsVKoytrS1//bWf/PnzA/dC/OnTf+PtXfmJHoOnpW+MExERETFjSUnJxMfHGf1LSEggJSWFzz//jGrVqtOkyRsMHDiEY8eOsGjRPKP7X7x4gXHjxnD8+HHWr1/LsmWLefPNYACKFi1G/fqNGD58CJs3/8S5c2f566/9zJ07i61btwDQrl0nDh78i9GjR3L06BFOnTrJDz98R0JCAgD58xfkr7/2c/78ORISEkhNTaVly1Zcu3aNsLBPiYk5wNmzZ9ixYxvh4UNJSUnBycmJpk2bMXnyV+zevYvjx48SHh6GldXLi6YaCRYRERGL9E8Zxd+xYyvNmjU0Wla0aDHq1WvIhQvnGTXqSwDc3NwYMOBTwsI+pWrV6pQuXQaAhg2bcOfOHd566y2sra15881gmjX73xzggQOHMHv2DCZOHEds7CVcXHJRoYIXNWrUMuxr7NiJTJs2iS5dOmJvn43y5T2pW7cBAG+/3Y4RI8Jo1+4t7ty5Y7hE2tdfz+Drryfw0Ue9SE5OIn/+AlSr5mcYpe7Row+3bt0kJOQjnJyyExzclhs3brzwxzOdVVpaWtpL29s/XGzs9Ze+T1Nd/snx1bUm2a+5/0KytP4A9cnD6DXycOoT82Jp/QHm3ycvU/q3ufXr9zGurtm5ciWRu3dTTV3WC+XuniNL7TQdQkREREQsjkKwiIiIiFgczQkWERER+ZeaOHGaqUswWxoJFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4CsEiIiIiYnF0iTQRERERC9BqcXeT7Ndcv8FPI8EiIiIiYnEUgkVERETE4igEi4iIiIjFMfmc4AULFrBw4ULOnj0LQOnSpenRowcBAQEA3Llzh5EjR7J69WqSkpLw9/dnyJAhuLm5GbZx7tw5wsLC2LFjB05OTjRv3px+/fpha/u/w9uxYwcjR47kyJEjFChQgO7duxMUFPRyD1ZEREQs3rsjfzLJfh1fNcluzZbJR4Lz589P//79+f7771m2bBnVq1enZ8+eHDlyBIDw8HB+/vlnxo0bx9y5c7l06RK9evUy3D8lJYWuXbuSnJzMokWLGDlyJD/88APjx483tDl9+jRdu3alWrVq/Pjjj3Ts2JFBgwbx22+/vfTjFRERERHTM3kIDgwMJCAggOLFi1OiRAk++ugjnJyciIqK4vr16yxbtozQ0FD8/Pzw9PQkPDycvXv3EhUVBcCWLVs4evQo//3vfylXrhwBAQH06dOH+fPnk5SUBMCiRYsoXLgwoaGhlCxZknbt2tGgQQO+/fZb0x24iIiIiJiMyadD3C8lJYW1a9dy8+ZNfHx82L9/P8nJydSoUcPQpmTJkhQsWJCoqCi8vb2JioqiTJkyRtMj/P39CQsL4+jRo5QvX56oqCj8/PyM9uXv7094ePgT1WdtbYW1tdWzHaQ8kq2tyd+XyQPUJ+ZF/WF+1CfmR31iXsy1P8wiBB86dIjg4GDu3LmDk5MTkyZNolSpUsTExGBnZ0fOnDmN2ufJk4fY2FgA4uLijAIwYLj9uDY3btzg9u3bODg4ZKnO3LmzY2WlEPwiubpmN3UJ8gD1iXlRf5gf9Yn5UZ+YF3PtD7MIwSVKlGD58uVcv36ddevWERISwrx580xdVgaXLydqJPgFu3Il0dQlyAPUJ+ZF/WF+1CfmR31iXl52f2Q1dJtFCLa3t6dYsWIAeHp6sm/fPubMmUOjRo1ITk7m2rVrRqPB8fHxuLu7A/dGdKOjo422FxcXB2DUJn3Z/W2cnZ2zPAoMkJqaRmpq2pMfoGTZ3buppi5BHqA+MS/qD/OjPjE/6hPzYq79YZaTNFJTU0lKSsLT0xM7Ozu2bdtmWHf8+HHOnTuHt7c3AN7e3hw+fJj4+HhDm61bt+Ls7EypUqUMbbZv3260j61btxq2ISIiIiKWxeQheMyYMezatYszZ85w6NAhxowZw86dO3n99dfJkSMHLVu2ZOTIkWzfvp39+/czcOBAfHx8DAHW39+fUqVKMWDAAA4ePMhvv/3GuHHjaNu2Lfb29gAEBwdz+vRpRo0axbFjx5g/fz5r1qyhU6dOpjtwERERETEZk0+HiI+PJyQkhEuXLpEjRw48PDyYMWMGNWvWBGDgwIFYW1vTu3dvoy/LSGdjY8OUKVMICwujdevWODo60qJFC3r37m1oU6RIEaZOnUpERARz5swhf/78DB8+nFq1ar304xURERER0zN5CH7cZcqyZcvGkCFDjILvgwoVKsT06dMfuZ1q1aqxfPnypylRRERERP5lTD4dQkRERETkZVMIFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4CsEiIiIiYnEUgkVERETE4igEi4iIiIjFUQgWEREREYujECwiIiIiFkchWEREREQsjkKwiIiIiFgchWARERERsTgKwSIiIiJicRSCRURERMTiKASLiIiIiMVRCBYRERERi6MQLCIiIiIWRyFYRERERCyOQrCIiIiIWByFYBERERGxOArBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4Jg/BU6dOpWXLlvj4+ODn50ePHj04fvy4UZv27dvj4eFh9G/w4MFGbc6dO0eXLl2oVKkSfn5+fPHFF9y9e9eozY4dO2jRogWenp7Uq1eP77///oUfn4iIiIiYH1tTF7Bz507atm2Ll5cXKSkpjB07ls6dO7Nq1SqcnJwM7Vq1akXv3r0Ntx0dHQ0/p6Sk0LVrV9zc3Fi0aBGXLl0iJCQEOzs7+vbtC8Dp06fp2rUrwcHBjB49mm3btjFo0CDc3d2pVavWyztgERERETE5k4fgGTNmGN0eOXIkfn5+HDhwgKpVqxqWOzg44O7unuk2tmzZwtGjR5k1axZubm6UK1eOPn36MHr0aHr16oW9vT2LFi2icOHChIaGAlCyZEl2797Nt99+qxAsIiIiYmFMHoIfdP36dQBcXFyMlkdGRrJixQrc3d2pXbs2PXr0MIwGR0VFUaZMGdzc3Azt/f39CQsL4+jRo5QvX56oqCj8/PyMtunv7094eHiWa7O2tsLa2uppD02ywNbW5DN05AHqE/Oi/jA/6hPzoz4xL+baH2YVglNTUwkPD8fX15cyZcoYljdt2pSCBQuSN29eDh06xOjRozlx4gQTJ04EIC4uzigAA4bbsbGxj2xz48YNbt++jYODw2Pry507O1ZWCsEvkqtrdlOXIA9Qn5gX9Yf5UZ+YH/WJeTHX/jCrEDx06FCOHDnCggULjJa3bt3a8LOHhwfu7u506tSJv//+m6JFi760+i5fTtRI8At25UqiqUuQB6hPzIv6w/yoT8yP+sS8vOz+yGroNpsQ/Pnnn/PLL78wb9488ufP/8i2lSpVAuDUqVMULVoUNzc3oqOjjdrExcUBGOYRu7m5GZbd38bZ2TlLo8AAqalppKamZamtPJ27d1NNXYI8QH1iXtQf5kd9Yn7UJ+bFXPvD5JM00tLS+Pzzz9mwYQOzZ8+mSJEij71PTEwM8L+A6+3tzeHDh4mPjze02bp1K87OzpQqVcrQZvv27Ubb2bp1K97e3s/pSERERETkn8LkIXjo0KGsWLGCMWPGkD17dmJjY4mNjeX27dsA/P3330yaNIn9+/dz5swZNm3aREhICFWrVqVs2bLAvRPcSpUqxYABAzh48CC//fYb48aNo23bttjb2wMQHBzM6dOnGTVqFMeOHWP+/PmsWbOGTp06merQRURERMRETD4dYuHChcC9L8S4X0REBEFBQdjZ2bFt2zbmzJnDzZs3KVCgAPXr16dHjx6GtjY2NkyZMoWwsDBat26No6MjLVq0MLqucJEiRZg6dSoRERHMmTOH/PnzM3z4cF0eTURERMQCmTwEHzp06JHrCxQowLx58x67nUKFCjF9+vRHtqlWrRrLly9/kvJERERE5F/I5NMhREREREReNoVgEREREbE4CsEiIiIiYnEUgkVERETE4igEi4iIiIjFUQgWEREREYujECwiIiIiFkchWEREREQsjkKwiIiIiFgchWARERERsTgKwSIiIiJicRSCRURERMTiKASLiIiIiMVRCBYRERERi6MQLCIiIiIWRyFYRERERCyOQrCIiIiIWByFYBERERGxOArBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFhERERGLoxAsIiIiIhbnqUJwnTp1OHjwYKbrDh8+TJ06dZ6pKBERERGRF+mpQvDZs2dJSkrKdN3t27e5cOHCMxUlIiIiIvIi2Wa14Z07d7h16xZpaWkA3Lhxg4SEhAxtNm7cSN68eZ9rkSIiIiIiz1OWQ/D06dOZNGkSAFZWVnTu3PmhbXv16vXslYmIiIiIvCBZDsF169alUKFCpKWlMXDgQLp3707RokWN2tjZ2VGyZEnKlSv33AsVEREREXleshyCy5YtS9myZYF7I8EBAQHkzp37hRUmIiIiIvKiZDkE369FixbPuw4RERERkZfmqULw7du3mTx5MuvWrePChQuZXikiJiYmS9uaOnUq69ev5/jx4zg4OODj40P//v155ZVXDG3u3LnDyJEjWb16NUlJSfj7+zNkyBDc3NwMbc6dO0dYWBg7duzAycmJ5s2b069fP2xt/3eIO3bsYOTIkRw5coQCBQrQvXt3goKCnuYhEBEREZF/sKcKwUOHDmXlypU0bdqUkiVLYmdn99QF7Ny5k7Zt2+Ll5UVKSgpjx46lc+fOrFq1CicnJwDCw8PZvHkz48aNI0eOHAwbNoxevXqxaNEiAFJSUujatStubm4sWrSIS5cuERISgp2dHX379gXg9OnTdO3aleDgYEaPHs22bdsYNGgQ7u7u1KpV66nrFxEREZF/nqcKwT///DMhISG0a9fumQuYMWOG0e2RI0fi5+fHgQMHqFq1KtevX2fZsmWMHj0aPz8/4F4obty4MVFRUXh7e7NlyxaOHj3KrFmzcHNzo1y5cvTp04fRo0fTq1cv7O3tWbRoEYULFyY0NBSAkiVLsnv3br799luFYBEREREL81Qh2MbGhuLFiz/nUu65fv06AC4uLgDs37+f5ORkatSoYWhTsmRJChYsaAjBUVFRlClTxmh6hL+/P2FhYRw9epTy5csTFRVlCNH3twkPD89ybdbWVlhbWz3L4clj2Nrqm7zNjfrEvKg/zI/6xPyoT8yLufbHU4Xgt99+mx9//BF/f//nWkxqairh4eH4+vpSpkwZAOLi4rCzsyNnzpxGbfPkyUNsbKyhzf0BGDDcflybGzducPv2bRwcHB5bX+7c2bGyUgh+kVxds5u6BHmA+sS8qD/Mj/rE/KhPzIu59sdThWAHBwd2795NcHAwfn5+GQKqlZUVnTp1euLtDh06lCNHjrBgwYKnKeuFu3w5USPBL9iVK4mmLkEeoD4xL+oP86M+MT/qE/Pysvsjq6H7qULw6NGjgXtXZIiKisqw/mlC8Oeff84vv/zCvHnzyJ8/v2G5m5sbycnJXLt2zShsx8fH4+7ubmgTHR1ttL24uDgAozbpy+5v4+zsnKVRYIDU1DRSU9Oe6Ljkydy9m2rqEuQB6hPzov4wP+oT86M+MS/m2h9PFYIPHjz43ApIS0tj2LBhbNiwgblz51KkSBGj9Z6entjZ2bFt2zYaNGgAwPHjxzl37hze3t4AeHt7M2XKFOLj48mTJw8AW7duxdnZmVKlShna/Prrr0bb3rp1q2EbIiIiImI5TD5TeejQoaxYsYIxY8aQPXt2YmNjiY2N5fbt2wDkyJGDli1bMnLkSLZv387+/fsZOHAgPj4+hgDr7+9PqVKlGDBgAAcPHuS3335j3LhxtG3bFnt7ewCCg4M5ffo0o0aN4tixY8yfP581a9Y81bQNEREREflne6qR4F27dj22TdWqVbO0rYULFwLQvn17o+URERGGL7IYOHAg1tbW9O7d2+jLMtLZ2NgwZcoUwsLCaN26NY6OjrRo0YLevXsb2hQpUoSpU6cSERHBnDlzyJ8/P8OHD9fl0UREREQs0FOF4Pbt22NlZUVa2v/mxz541YSsfmPcoUOHHtsmW7ZsDBkyxCj4PqhQoUJMnz79kdupVq0ay5cvz1JdIiIiIvLv9VQhOLMgefXqVbZs2cL69esZOnTos9YlIiIiIvLCPFUILlu2bKbLq1WrhoODA4sXL6Z69erPVJiIiIiIyIvy3E+M8/X1ZfPmzc97syIiIiIiz81zD8EbN24kV65cz3uzIiIiIiLPzVNNh+jWrVuGZcnJyZw4cYLz58/z8ccfP3NhIiIiIiIvylOF4MTEjF9/ly1bNmrUqEGDBg102TERERERMWtPFYLnzp37vOsQEREREXlpnnlO8O3bt7l06ZLhG95ERERERMzdU40EA/z8889MnDiRmJgY0tLSsLKyoly5cvTu3ZuAgIDnWaOIiIiIyHP1VCPBGzdupEePHtjZ2REaGsqYMWMICQnB3t6e7t27s3Hjxuddp4iIiIjIc/NUI8ETJ06kSZMmjB492mh5x44d6d+/PxMnTqRu3brPpUARERERkeftqUaCjx8/TvPmzTNd16xZM44fP/4sNYmIiIiIvFBPFYJdXFw4ceJEputOnDiBi4vLMxUlIiIiIvIiPdV0iMaNGzN27FgcHBxo0KABOXPm5Pr166xdu5Zx48bRqlWr512niIiIiMhz81QhuF+/fpw7d47PPvuMwYMHY2try927d0lLS6N+/fr07dv3edcpIiIiIvLcPFUItre3Z8KECRw6dIg//viDa9eu4eLiQuXKlfHw8HjeNYqIiIiIPFdZnhN88uRJgoKC2Lx5s2GZh4cHbdu2pXv37rRp04YLFy4QFBTE6dOnX0ixIiIiIiLPQ5ZD8MyZM3FycnrkF2EEBASQPXt2ZsyY8VyKExERERF5EbIcgn///Xdatmz52HYtW7Zky5Ytz1SUiIiIiMiLlOUQfPHiRYoUKfLYdoULF+bixYvPVJSIiIiIyIuU5RCcPXt2rly58th2CQkJODk5PVNRIiIiIiIvUpZDsKenJ6tXr35su1WrVuHp6flMRYmIiIiIvEhZDsFt2rRhzZo1TJw4kZSUlAzrU1NTmThxImvXrqVt27bPtUgRERERkecpy9cJrlOnDu+99x4TJ05k0aJF+Pn5UbBgQQDOnz/Ptm3biIuLo3PnzgQGBr6wgkVEREREntUTfVlG//79qVq1KjNnzmTdunUkJSUBkC1bNnx9fRk+fPgjL6EmIiIiImIOnvgb4wICAggICCAlJYWEhAQAcuXKhY2NzfOuTURERETkhXiqr00GsLGxIU+ePM+zFhERERGRlyLLJ8aJiIiIiPxbKASLiIiIiMVRCBYRERERi2PyELxr1y66deuGv78/Hh4ebNy40Wh9aGgoHh4eRv86d+5s1CYhIYF+/frh6+tLlSpVGDhwIImJiUZtDh48SJs2bfDy8iIgIIDp06e/8GMTEREREfP01CfGPS83b97Ew8ODli1b0qtXr0zb1KpVi4iICMNte3t7o/X9+/cnNjaWWbNmkZyczMCBAxk8eDBjxowB4MaNG3Tu3Bk/Pz+GDh3K4cOHGThwIDlz5qR169Yv7uBERERExCyZPASnX3LtUezt7XF3d8903bFjx/jtt9/47rvv8PLyAmDQoEF06dKFAQMGkC9fPlasWEFycjLh4eHY29tTunRpYmJimDVrlkKwiIiIiAUyeQjOip07d+Ln50fOnDmpXr06H374Ia6urgDs3buXnDlzGgIwQI0aNbC2tiY6Opp69eoRFRVFlSpVjEaQ/f39mT59OlevXsXFxSVLdVhbW2FtbfV8D06M2NqafIaOPEB9Yl7UH+ZHfWJ+1CfmxVz7w+xDcK1atahXrx6FCxfm9OnTjB07lvfff5/FixdjY2NDXFwcuXPnNrqPra0tLi4uxMbGAhAXF0fhwoWN2ri5uRnWZTUE586dHSsrheAXydU1u6lLkAeoT8yL+sP8qE/Mj/rEvJhrf5h9CG7SpInh5/QT4+rWrWsYHX6ZLl9O1EjwC3blSuLjG8lLpT4xL+oP86M+MT/qE/Pysvsjq6Hb7EPwg4oUKYKrqyunTp3Cz88PNzc3Ll++bNTm7t27XL161TCP2M3Njbi4OKM26bfTR4SzIjU1jdTUtGc8AnmUu3dTTV2CPEB9Yl7UH+ZHfWJ+1CfmxVz7wzwnaTzChQsXSEhIMARcHx8frl27xv79+w1ttm/fTmpqKhUrVgTA29ubP/74g+TkZEObrVu3UqJEiSxPhRARERGRfw+Th+DExERiYmKIiYkB4MyZM8TExHDu3DkSExP54osviIqK4syZM2zbto0ePXpQrFgxatWqBUDJkiWpVasWn332GdHR0ezevZthw4bRpEkT8uXLB8Drr7+OnZ0dn376KUeOHGH16tXMmTOHd955x2THLSIiIiKmY/LpEPv376dDhw6G2+nXA27RogVhYWEcPnyY5cuXc/36dfLmzUvNmjXp06eP0ZUeRo8ezbBhw+jYsSPW1tbUr1+fQYMGGdbnyJGDGTNm8PnnnxMUFISrqys9evTQ5dFERERELJTJQ3C1atU4dOjQQ9fPmDHjsdvIlSuX4YsxHqZs2bIsWLDgiesTERERkX8fk0+HEBERERF52RSCRURERMTiKASLiIiIiMVRCBYRERERi6MQLCIiIiIWRyFYRERERCyOQrCIiIiIWByFYBERERGxOArBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4CsEiIiIiYnEUgkVERETE4igEi4iIiIjFUQgWEREREYujECwiIiIiFkchWEREREQsjkKwiIiIiFgchWARERERsTgKwSIiIiJicRSCRURERMTiKASLiIiIiMVRCBYRERERi6MQLCIiIiIWx+QheNeuXXTr1g1/f388PDzYuHGj0fq0tDS++uor/P39qVixIp06deLkyZNGbRISEujXrx++vr5UqVKFgQMHkpiYaNTm4MGDtGnTBi8vLwICApg+ffqLPjQRERERMVMmD8E3b97Ew8ODIUOGZLp++vTpzJ07l7CwMJYsWYKjoyOdO3fmzp07hjb9+/fn6NGjzJo1iylTpvDHH38wePBgw/obN27QuXNnChYsyPfff8+AAQOYOHEiixcvfuHHJyIiIiLmx9bUBQQEBBAQEJDpurS0NObMmUP37t2pW7cuAKNGjaJGjRps3LiRJk2acOzYMX777Te+++47vLy8ABg0aBBdunRhwIAB5MuXjxUrVpCcnEx4eDj29vaULl2amJgYZs2aRevWrV/asYqIiIiIeTB5CH6UM2fOEBsbS40aNQzLcuTIQaVKldi7dy9NmjRh79695MyZ0xCAAWrUqIG1tTXR0dHUq1ePqKgoqlSpgr29vaGNv78/06dP5+rVq7i4uGSpHmtrK6ytrZ7fAUoGtrYm/3BCHqA+MS/qD/OjPjE/6hPzYq79YdYhODY2FoA8efIYLc+TJw9xcXEAxMXFkTt3bqP1tra2uLi4GO4fFxdH4cKFjdq4ubkZ1mU1BOfOnR0rK4XgF8nVNbupS5AHqE/Mi/rD/KhPzI/6xLyYa3+YdQg2N5cvJ2ok+AW7ciXx8Y3kpVKfmBf1h/lRn5gf9Yl5edn9kdXQbdYh2N3dHYD4+Hjy5s1rWB4fH0/ZsmWBeyO6ly9fNrrf3bt3uXr1quH+bm5uhpHjdOm300eEsyI1NY3U1LQnPxDJsrt3U01dgjxAfWJe1B/mR31iftQn5sVc+8M8J2n8v8KFC+Pu7s62bdsMy27cuMGff/6Jj48PAD4+Ply7do39+/cb2mzfvp3U1FQqVqwIgLe3N3/88QfJycmGNlu3bqVEiRJZngohIiIiIv8eJg/BiYmJxMTEEBMTA9w7GS4mJoZz585hZWVFhw4d+Prrr9m0aROHDh1iwIAB5M2b13C1iJIlS1KrVi0+++wzoqOj2b17N8OGDaNJkybky5cPgNdffx07Ozs+/fRTjhw5wurVq5kzZw7vvPOOyY5bREREREzH5NMh9u/fT4cOHQy3IyIiAGjRogUjR47k/fff59atWwwePJhr165RuXJlvvnmG7Jly2a4z+jRoxk2bBgdO3bE2tqa+vXrM2jQIMP6HDlyMGPGDD7//HOCgoJwdXWlR48eujyaiIiIiIUyeQiuVq0ahw4deuh6Kysr+vTpQ58+fR7aJleuXIwZM+aR+ylbtiwLFix46jpFRERE5N/D5NMhREREREReNoVgEREREbE4CsEiIiIiYnEUgkVERETE4igEi4iIiIjFUQgWEREREYujECwiIiIiFkchWEREREQsjkKwiIiIiFgchWARERERsTgKwSIiIiJicRSCRURERMTiKASLiIiIiMVRCBYRERERi6MQLCIiIiIWRyFYRERERCyOQrCIiIiIWByFYBERERGxOArBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4CsEiIiIiYnEUgkVERETE4igEi4iIiIjFUQgWEREREYtj9iF4woQJeHh4GP1r2LChYf2dO3cYOnQo1apVw8fHhw8++IC4uDijbZw7d44uXbpQqVIl/Pz8+OKLL7h79+7LPhQRERERMRO2pi4gK0qXLs2sWbMMt21sbAw/h4eHs3nzZsaNG0eOHDkYNmwYvXr1YtGiRQCkpKTQtWtX3NzcWLRoEZcuXSIkJAQ7Ozv69u370o9FREREREzP7EeC4V7odXd3N/zLnTs3ANevX2fZsmWEhobi5+eHp6cn4eHh7N27l6ioKAC2bNnC0aNH+e9//0u5cuUICAigT58+zJ8/n6SkJBMelYiIiIiYyj9iJPjUqVP4+/uTLVs2vL296devHwULFmT//v0kJydTo0YNQ9uSJUtSsGBBoqKi8Pb2JioqijJlyuDm5mZo4+/vT1hYGEePHqV8+fJZrsPa2gpra6vnemxizNb2H/G+zKKoT8yL+sP8qE/Mj/rEvJhrf5h9CK5YsSIRERGUKFGC2NhYJk2aRNu2bYmMjCQuLg47Ozty5sxpdJ88efIQGxsLQFxcnFEABgy309tkVe7c2bGyUgh+kVxds5u6BHmA+sS8qD/Mj/rE/KhPzIu59ofZh+CAgADDz2XLlqVSpUrUrl2bNWvW4ODg8FJruXw5USPBL9iVK4mmLkEeoD4xL+oP86M+MT/qE/Pysvsjq6Hb7EPwg3LmzEnx4sX5+++/qVGjBsnJyVy7ds1oNDg+Ph53d3fg3qhvdHS00TbSrx6R3iarUlPTSE1Ne8YjkEe5ezfV1CXIA9Qn5kX9YX7UJ+ZHfWJezLU/zHOSxiMkJiZy+vRp3N3d8fT0xM7Ojm3bthnWHz9+nHPnzuHt7Q2At7c3hw8fJj4+3tBm69atODs7U6pUqZddvoiIiIiYAbMfCf7iiy+oXbs2BQsW5NKlS0yYMAFra2uaNm1Kjhw5aNmyJSNHjsTFxQVnZ2eGDx+Oj4+PIQT7+/tTqlQpBgwYwMcff0xsbCzjxo2jbdu22Nvbm/bgRERERMQkzD4EX7hwgb59+5KQkEDu3LmpXLkyS5YsMVwmbeDAgVhbW9O7d2+SkpLw9/dnyJAhhvvb2NgwZcoUwsLCaN26NY6OjrRo0YLevXub6pBERERExMTMPgR/+eWXj1yfLVs2hgwZYhR8H1SoUCGmT5/+vEsTERERkX+of9ycYBERERGRZ6UQLCIiIiIWRyFYRERERCyOQrCIiIiIWByFYBERERGxOArBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4CsEiIiIiYnEUgkVERETE4igEi4iIiIjFUQgWEREREYujECwiIiIiFkchWEREREQsjkKwiIiIiFgchWARERERsTgKwSIiIiJicRSCRURERMTiKASLiIiIiMVRCBYRERERi6MQLCIiIiIWRyFYRERERCyOQrCIiIiIWByFYBERERGxOArBIiIiImJxLC4Ez58/n8DAQLy8vHjrrbeIjo42dUkiIiIi8pJZVAhevXo1ERER9OzZkx9++IGyZcvSuXNn4uPjTV2aiIiIiLxEFhWCZ82aRatWrWjZsiWlSpVi6NChODg4sGzZMlOXJiIiIiIvka2pC3hZkpKSOHDgAF27djUss7a2pkaNGuzduzdL27C2tsLa2upFlSiAra1FvS/7R1CfmBf1h/lRn5gf9Yl5Mdf+sEpLS0szdREvw8WLF3nttddYtGgRPj4+huWjRo1i165dLF261ITViYiIiMjLZJ7RXERERETkBbKYEOzq6oqNjU2Gk+Di4+Nxc3MzUVUiIiIiYgoWE4Lt7e2pUKEC27ZtMyxLTU1l27ZtRtMjREREROTfz2JOjAN45513CAkJwdPTk4oVKzJ79mxu3bpFUFCQqUsTERERkZfIokJw48aNuXz5MuPHjyc2NpZy5crxzTffaDqEiIiIiIWxmKtDiIiIiIiks5g5wSIiIiIi6RSCRURERMTiKASLiIiIiMVRCBYRERERi6MQLEbmz59PYGAgXl5evPXWW0RHR5u6JIu2a9cuunXrhr+/Px4eHmzcuNHUJVm0qVOn0rJlS3x8fPDz86NHjx4cP37c1GVZrAULFvD666/j6+uLr68vrVu3ZvPmzaYuS+4zbdo0PDw8GDFihKlLsVgTJkzAw8PD6F/Dhg1NXZZZUAgWg9WrVxMREUHPnj354YcfKFu2LJ07d87wLXvy8ty8eRMPDw+GDBli6lIE2LlzJ23btmXJkiXMmjWLu3fv0rlzZ27evGnq0ixS/vz56d+/P99//z3Lli2jevXq9OzZkyNHjpi6NAGio6NZtGgRHh4epi7F4pUuXZotW7YY/i1YsMDUJZkFi7pOsDzarFmzaNWqFS1btgRg6NCh/PLLLyxbtowuXbqYuDrLFBAQQEBAgKnLkP83Y8YMo9sjR47Ez8+PAwcOULVqVRNVZbkCAwONbn/00UcsXLiQqKgoSpcubaKqBCAxMZGPP/6Y4cOH8/XXX5u6HItnY2ODu7u7qcswOxoJFgCSkpI4cOAANWrUMCyztramRo0a7N2714SViZiv69evA+Di4mLiSiQlJYVVq1Zx8+ZNfHx8TF2Oxfv8888JCAgw+psipnPq1Cn8/f2pU6cO/fr149y5c6YuySxoJFgAuHLlCikpKeTJk8doeZ48eTTnUSQTqamphIeH4+vrS5kyZUxdjsU6dOgQwcHB3LlzBycnJyZNmkSpUqVMXZZFW7VqFX/99RffffedqUsRoGLFikRERFCiRAliY2OZNGkSbdu2JTIyEmdnZ1OXZ1IKwSIiT2Ho0KEcOXJEc+tMrESJEixfvpzr16+zbt06QkJCmDdvnoKwiZw/f54RI0Ywc+ZMsmXLZupyBIym1JUtW5ZKlSpRu3Zt1qxZw1tvvWXCykxPIVgAcHV1xcbGJsNJcPHx8bi5uZmoKhHz9Pnnn/PLL78wb9488ufPb+pyLJq9vT3FihUDwNPTk3379jFnzhw+//xzE1dmmQ4cOEB8fDxBQUGGZSkpKezatYv58+ezb98+bGxsTFih5MyZk+LFi/P333+buhSTUwgW4N4fkgoVKrBt2zbq1q0L3Pu4d9u2bbRr187E1YmYh7S0NIYNG8aGDRuYO3cuRYoUMXVJ8oDU1FSSkpJMXYbFql69OpGRkUbLPvnkE1555RXef/99BWAzkJiYyOnTp3WiHArBcp933nmHkJAQPD09qVixIrNnz+bWrVtG7+jl5UpMTDR6t37mzBliYmJwcXGhYMGCJqzMMg0dOpSVK1cyefJksmfPTmxsLAA5cuTAwcHBxNVZnjFjxvDaa69RoEABEhMTWblyJTt37sxwFQ95eZydnTPMkXdyciJXrlyaO28iX3zxBbVr16ZgwYJcunSJCRMmYG1tTdOmTU1dmskpBItB48aNuXz5MuPHjyc2NpZy5crxzTffaDqECe3fv58OHToYbkdERADQokULRo4caaqyLNbChQsBaN++vdHyiIgIvVk0gfj4eEJCQrh06RI5cuTAw8ODGTNmULNmTVOXJmI2Lly4QN++fUlISCB37txUrlyZJUuWkDt3blOXZnJWaWlpaaYuQkRERETkZdJ1gkVERETE4igEi4iIiIjFUQgWEREREYujECwiIiIiFkchWEREREQsjkKwiIiIiFgchWARERERsTgKwSIiIiJicRSCRURMbMWKFQQHB+Pj44OPjw+tW7dm+fLlT7WtCRMmsGfPnudboIjIv5C+NllExISGDRvG/PnzadmyJT169MDKyop169YRGhrKvn37+Oyzz55oexMnTsTJyQlfX98XVLGIyL+DQrCIiIls2rSJefPm0atXLz744APD8lq1apE3b14mTZpEzZo1CQwMNGGVIiL/TpoOISJiIrNnz8bFxYV33303w7rOnTvj4uLC7NmzAWjfvj1du3Y1ahMTE4OHhwc7duwAwMPDA4BRo0bh4eFhtC41NZVZs2bRqFEjPD09qVmzJr179+b69euG7e3atYvg4GAqVqxItWrV+OSTT0hISDCsP3PmDB4eHixfvpzBgwdTpUoV/Pz8mDVrFgCrVq2iQYMG+Pr60qtXL65du2ZU77Vr1wgLC8Pf3x9PT0+CgoLYsmXLMz6KIiJPRyPBIiImcPfuXfbu3ct//vMfsmfPnmF99uzZqVatGps3b+bu3btZ2ubixYtp3bo17du3p2nTpgCUKlUKuDftYvHixXTs2JGaNWuSmJjIL7/8ws2bN8mRIwf79+/nnXfeoVq1anz11VfExcUxZswYjh49yqJFi7CxsTHsZ9y4cdSvX5+vvvqKjRs3MnLkSC5fvszOnTv5+OOPuXHjBsOHD+e///0vw4YNAyApKYl33nmH+Ph4PvzwQ/Lly8eKFSvo2rUr33//vSHAi4i8LArBIiImcOXKFZKSkihQoMBD2xQoUIA7d+4YjcY+ire3t+F+6T8DnDhxgoULF/LRRx8ZjSY3aNDA8POUKVNwd3dnypQp2NnZGbbTuXNnNm/ebDQlw9vbm4EDBwJQvXp11q9fz7x58/jpp59wdXUF4NChQ3z33XeGEBwZGcnBgwf58ccfDcG8Vq1anDp1ismTJ/PVV19l6RhFRJ4XTYcQEfmX2759O2lpabz55psPbfPHH39Qp04dQwAG8Pf3J2fOnOzevduobc2aNQ0/29jYUKRIEcqWLWsIwADFixfn2rVrJCYmAvD7779TpkwZihcvzt27dw3/atSowb59+57XoYqIZJlGgkVETMDV1RV7e3vOnz//0Dbnz58nW7Zs5MqV65n2lZCQgK2tLXny5Hlom2vXrmW6Pk+ePFy9etVoWY4cOYxu29nZ4eTklGEZwJ07d8iePTtXrlzhr7/+okKFChn2cf9UCxGRl0UhWETEBGxtbfHx8WHnzp3cvHkzQ4i8efMmO3fuxMfHB1tbW+zt7UlOTjZq82A4fZhcuXJx9+5d4uPjHxqEXVxciI+Pz7A8Pj4eFxeXLB7Vw7m4uODh4cGIESOeeVsiIs+DpkOIiJhIx44dSUhIYObMmRnWzZw5k4SEBDp27AhA/vz5OXHiBGlpaYY2v//+e4b72dnZcefOHaNl1atXx8rKimXLlj20lsqVK7Np0yajk/B+//13rl27RuXKlZ/42B5Uo0YNTp8+Td68efHy8srwT0TkZdNIsIiIidSpU4d27doxceJELly4QMOGDQFYv349S5YsoV27doYT0ho0aGA40axu3brs2bOHdevWZdjmK6+8wqZNm6hSpQqOjo6UKFGCEiVKEBwczFdffcXVq1fx8/Pj9u3b/PLLL3zwwQfky5ePbt26ERwcTNeuXWnfvr3h6hAVK1YkICDgmY+1efPmLFq0iA4dOvDuu+9SvHhxrl+/zl9//UVycjL9+vV75n2IiDwJhWARERP67LPPqFSpEgsWLDB8YUaZMmUYOXIkzZs3N7R77bXX+Pjjj5k3bx4//PADr732GkOHDqVTp05G2xs8eDDh4eG8//773L59mzlz5lCtWjUGDx5M4cKFWbp0KbNnzyZXrlxUrVrVcHk2T09PZs6cydixY/nggw9wcnIiMDCQkJCQ5zJn197enjlz5jBhwgSmTJlCbGwsuXLlonz58rRp0+aZty8i8qSs0u7/bE1ERERExAJoTrCIiIiIWByFYBERERGxOArBIiIiImJxFIJFRERExOIoBIuIiIiIxVEIFhERERGLoxAsIiIiIhZHIVhERERELI5CsIiIiIhYHIVgEREREbE4CsEiIiIiYnH+D162aZ/tikXMAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(8, 4))\n",
+    "index = np.arange(n_outcomes)\n",
+    "ax.bar(index - 0.15, summary['observed'], width=0.3, label=\"Observed\", color=\"#4C72B0\")\n",
+    "ax.bar(index + 0.15, summary['expected'], width=0.3, label=\"Expected\", color=\"#55A868\")\n",
+    "ax.set_xlabel(\"Outcome\")\n",
+    "ax.set_ylabel(\"Count\")\n",
+    "ax.set_title(\"Empirical vs. Expected Counts under WAMECU Bias\")\n",
+    "ax.set_xticks(index)\n",
+    "ax.legend()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bb497ec",
+   "metadata": {},
+   "source": [
+    "## 3. Chi-square Test\n",
+    "\n",
+    "A chi-square goodness-of-fit test quantifies the probability that the observed counts arose from the unbiased baseline distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bd9e96cc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:33.053562Z",
+     "iopub.status.busy": "2025-09-28T01:13:33.053073Z",
+     "iopub.status.idle": "2025-09-28T01:13:33.062351Z",
+     "shell.execute_reply": "2025-09-28T01:13:33.061224Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(50.90920000000001, 9.02720231898968e-10)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "baseline_prob = np.full(n_outcomes, 1.0 / n_outcomes)\n",
+    "expected_baseline = baseline_prob * n_trials\n",
+    "chi2_stat, chi2_p = chi_square_statistic(summary['observed'].values, expected_baseline)\n",
+    "chi2_stat, chi2_p"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c42aa84c",
+   "metadata": {},
+   "source": [
+    "A small p-value indicates that the unbiased baseline is implausible. Here the test rejects the null hypothesis, signalling detectable bias in the draws."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5ba4c83",
+   "metadata": {},
+   "source": [
+    "## 4. Entropy Diagnostics\n",
+    "\n",
+    "Entropy measures disorder in the distribution. Comparing the empirical entropy to the unbiased baseline reveals whether the system exhibits additional structure (lower entropy) or noise (higher entropy)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9bcfc8b2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:33.065501Z",
+     "iopub.status.busy": "2025-09-28T01:13:33.065193Z",
+     "iopub.status.idle": "2025-09-28T01:13:33.071952Z",
+     "shell.execute_reply": "2025-09-28T01:13:33.070733Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-0.0018435666532918837"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "empirical_prob = summary['observed'].values / n_trials\n",
+    "entropy_difference = entropy_gap(empirical_prob, baseline_prob)\n",
+    "entropy_difference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b756ef8c",
+   "metadata": {},
+   "source": [
+    "A negative entropy gap means the empirical draws are more concentrated than the uniform baseline, consistent with the chi-square alert. Positive values would indicate higher randomness than expected."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/WAMECU_prototype.ipynb
+++ b/notebooks/WAMECU_prototype.ipynb
@@ -22,58 +22,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "4d46021a",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:12:57.397406Z",
+     "iopub.status.busy": "2025-09-28T01:12:57.396984Z",
+     "iopub.status.idle": "2025-09-28T01:13:00.012346Z",
+     "shell.execute_reply": "2025-09-28T01:13:00.011453Z"
+    }
+   },
    "outputs": [],
    "source": [
-    "import math\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
-    "import matplotlib.pyplot as plt\n",
-    "from typing import Iterable\n",
     "\n",
     "plt.style.use(\"seaborn-v0_8\")\n",
     "\n",
-    "def wamecu_probabilities(n_outcomes: int, beta: Iterable[float]) -> np.ndarray:\n",
-    "    \"\"\"Compute WAMECU-adjusted probabilities.\n",
+    "project_root = Path().resolve()\n",
+    "for candidate in {project_root / \"src\", project_root.parent / \"src\"}:\n",
+    "    if candidate.exists() and str(candidate) not in sys.path:\n",
+    "        sys.path.append(str(candidate))\n",
     "\n",
-    "    Parameters\n",
-    "    ----------\n",
-    "    n_outcomes : int\n",
-    "        Number of equally likely baseline outcomes.\n",
-    "    beta : Iterable[float]\n",
-    "        Bias coefficients associated with each outcome.\n",
-    "\n",
-    "    Returns\n",
-    "    -------\n",
-    "    np.ndarray\n",
-    "        Normalized probability distribution incorporating bias.\n",
-    "    \"\"\"\n",
-    "    beta = np.asarray(list(beta), dtype=float)\n",
-    "    if beta.size != n_outcomes:\n",
-    "        raise ValueError(\"beta vector must match number of outcomes\")\n",
-    "\n",
-    "    base = np.full(n_outcomes, 1.0 / n_outcomes)\n",
-    "    adjusted = base * (1 + beta)\n",
-    "\n",
-    "    # Guard against negative probabilities from large negative beta values.\n",
-    "    if np.any(adjusted < 0):\n",
-    "        raise ValueError(\"bias coefficients yield negative probabilities\")\n",
-    "\n",
-    "    total = adjusted.sum()\n",
-    "    if total <= 0:\n",
-    "        raise ValueError(\"bias coefficients collapse the probability mass\")\n",
-    "    if not math.isclose(total, 1.0):\n",
-    "        adjusted = adjusted / total\n",
-    "    return adjusted\n",
-    "\n",
-    "\n",
-    "def simulate_draws(probabilities: np.ndarray, n_trials: int, seed: int | None = None) -> np.ndarray:\n",
-    "    \"\"\"Simulate draws from a categorical distribution.\"\"\"\n",
-    "    rng = np.random.default_rng(seed)\n",
-    "    support = np.arange(probabilities.size)\n",
-    "    return rng.choice(support, size=n_trials, p=probabilities)"
+    "from wamecu import simulate_draws, wamecu_probabilities\n"
    ]
   },
   {
@@ -88,10 +63,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "073073c2",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:00.021717Z",
+     "iopub.status.busy": "2025-09-28T01:13:00.020678Z",
+     "iopub.status.idle": "2025-09-28T01:13:00.033936Z",
+     "shell.execute_reply": "2025-09-28T01:13:00.032961Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.18      , 0.17      , 0.165     , 0.16333333, 0.16666667,\n",
+       "       0.155     ])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "n_outcomes = 6\n",
     "beta = np.array([0.08, 0.02, -0.01, -0.02, 0.0, -0.07])\n",
@@ -119,10 +113,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "c431b644",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:00.038073Z",
+     "iopub.status.busy": "2025-09-28T01:13:00.037486Z",
+     "iopub.status.idle": "2025-09-28T01:13:00.056675Z",
+     "shell.execute_reply": "2025-09-28T01:13:00.055126Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    3616\n",
+       "1    3439\n",
+       "2    3214\n",
+       "3    3307\n",
+       "4    3330\n",
+       "5    3094\n",
+       "Name: count, dtype: int64"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "n_trials = 20_000\n",
     "outcomes = simulate_draws(probabilities, n_trials, seed=42)\n",
@@ -142,10 +160,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "ea82134a",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:00.060738Z",
+     "iopub.status.busy": "2025-09-28T01:13:00.060390Z",
+     "iopub.status.idle": "2025-09-28T01:13:00.320508Z",
+     "shell.execute_reply": "2025-09-28T01:13:00.318980Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAsEAAAGKCAYAAADtxpxGAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjYsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvq6yFwwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAXg1JREFUeJzt3XdclfX///EHU0UURHDvAQ5QQA1RlNymWY5ScqRliZojR2JmiiM0UzNHOTJzjzJNy23px72SHLn3FnCAoLLO7w9/nK9HUHGeU+d5v9246bmu93Vdr+u8D/Dkfd7numwMBoMBERERERErYmvuAkREREREXjaFYBERERGxOgrBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhERERGroxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVg+c+bMGECXl5eXLt2zdylvHReXl5MmDDB3GXIU9ixYwdeXl7s2LHD3KUI8Msvv+Dl5cX58+fNXYo8Z/pes14KwfKvdOzYMfr27UuNGjXw9vYmKCiIPn36cOzYMXOXJpnk5eX10K9BgwaZu7xMmzx5MuvWrTN3GZw9e5ZBgwZRp04dfHx88Pf3JyQkhJkzZ3Lnzh1zlwfA3Llz+eWXX8xdhkVbsWIFXl5erF27Nt26N954Ay8vL7Zv355u3auvvkpISEi65W+99RZeXl7Mmzcvw+OlhXsvLy92796dbr3BYCA4OBgvLy9CQ0NN1j3p9/COHTvo1q0b1atXx9vbm8DAQDp37syaNWtM2nh5ebFq1aoM6x06dCheXl4Zrrtf//79TeopV64cwcHB9OrVi+PHjz92e7EO9uYuQORJrVmzht69e+Pq6kqLFi0oVKgQFy5c4Oeff2b16tV8/fXX1KtXz9xlSiZUr16dN998M93y4sWLm6GapzNlyhQaNGhA3bp1zVbDhg0b6NmzJ46Ojrz55pt4enqSlJTEnj17+Oqrrzh+/DjDhg0zW31p5s+fT65cuWjevLm5S7FYlSpVAmDPnj0mP8du3brFsWPHsLe356+//qJq1arGdZcuXeLSpUs0atTIZF+nT59m//79FCxYkOXLl9O6deuHHjdLliz89ttvVK5c2WT5zp07uXz5Mo6Ojhlul9nv4fHjxzNp0iSKFStGq1atKFCgADdu3GDjxo10796d0aNH06RJk4fW9zQcHR0ZPnw4ACkpKZw9e5YFCxawadMmfv/9d/LmzQtAlSpV2LdvHw4ODs/1+GL5FILlX+Xs2bP069ePwoULM3fuXNzc3Izr3n33Xdq0aUO/fv1YtmwZhQsXNmOl6aWmppKUlESWLFnMXYrFKFasWIa/QCXzzp07R69evShQoAAzZ84kT548xnVt2rThzJkzbNiwwXwFSoYSEhJwcnJKtzxv3rwUKlSIPXv2mCzfu3cvBoOBhg0bpluX9jgtQKdZtmwZuXPnpn///vTo0YPz589TqFChDOsJDg5m1apVDBw4EHv7/4sGv/32G+XLl+fGjRsZbpeZ7+FVq1YxadIkGjRowJgxY0zC5gcffMCmTZtITk5+5D6ehr29fbrafH19CQ0NZePGjbRs2RIAW1tb/Vy2UpoOIf8q33//Pbdv32bYsGEmARjAzc2NoUOHkpCQwLRp09Jte/36dXr27Im/vz8BAQEMHz6cu3fvmrTZsmUL77zzDpUrV8bPz48GDRowduxYkzaJiYmMHz+eevXq4e3tTXBwMKNGjSIxMdGknZeXF0OHDmXZsmU0btwYHx8f/vjjD1555RU+/fTTdPXdunULHx8fvvzyyyc+VmJiIhEREVStWhU/Pz86d+7M5cuXH/t8RkdHU65cOSZOnJhu3cmTJ/Hy8mLOnDkAJCUlMXHiROrXr4+Pjw8BAQG88847bNmy5bHHeVonTpygQoUK9OvXz2T57t27KVu2LF999ZVxWe3atQkNDWXz5s28+eab+Pj40KhRI5O3WtPExsbyxRdfEBwcjLe3N/Xq1WPq1KmkpqaatEtNTWXmzJk0adIEHx8fqlatSseOHdm/fz9wr48TEhJYsmSJ8W3X/v37G7e/cuUKn376KdWqVcPb25vGjRvz888/p6vn8uXLdO3aFV9fXwIDA4mIiEjXxw/z/fffk5CQwBdffGESgNMULVqU9u3bGx8nJyczadIk6tati7e3N7Vr12bs2LEZvn4zmk9eu3Ztk3NMezt9z549jBgxgqpVq+Lr68tHH31kMg+/du3aHDt2jJ07dxqfq3bt2gFP/9pKm+//oIzm76a9Pnbv3s1bb72Fj48PderUYenSpem2P3bsGO+++y4VKlSgZs2afPvtt+leG2k2btxI69at8fX1xc/Pj06dOqWbltW/f3/8/Pw4e/YsH374IX5+fvTt2/eh51WpUiUOHTpkMo3lr7/+onTp0tSoUYO///7bpJ6//voLGxsb/P39Tfbz22+/0aBBA1599VVy5MjBb7/99tBjNm7cmBs3bpg854mJiaxevfqZR2i/+eYbXF1diYiIyHC0tUaNGtSqVeuZjpFZ7u7uANjZ2RmXZTQnePfu3fTo0YNXX33V+LM3IiIi3dSiqKgoPv30U2rWrGmcmtelSxfNHf+X0Eiw/Kv8+eefFCxYMN1bdmmqVKlCwYIF2bhxY7p1H3/8MQULFqRPnz5ERkYye/ZsYmNjGTVqFHDvF19oaCheXl706NEDR0dHzpw5w19//WXcR2pqKl26dGHPnj20bNmSkiVLcvToUWbOnMnp06f59ttvTY65fft2Vq5cSZs2bciVKxfFihWjbt26rF27liFDhpi8xbhu3ToSExONb2k+ybE+++wzli1bxuuvv46/vz/bt2+nU6dOj30+3d3dqVKlCitXrqRbt24m61asWIGdnR0NGzYEYOLEiUyZMoW3336bChUqcOvWLQ4cOMDBgwepXr36Y4+Vkbt372b4gUVnZ2ccHR0pWbIkPXv2ZNSoUTRo0IA6deqQkJDAp59+SokSJejZs6fJdqdPn6ZXr16EhITQrFkzFi9eTM+ePfn++++NNd6+fZu2bdty5coVQkJCyJ8/P3v37mXs2LFERUXx2WefGff32Wef8csvv1CzZk3eeustUlJS2L17N3///Tc+Pj6MGjWKgQMHUqFCBeOoUpEiRYB7f2C0bNkSGxsb2rRpg5ubG//73//47LPPuHXrFh06dADgzp07tG/fnkuXLtGuXTvy5MnDr7/+muG8z4z8+eefFC5cOF0AepiBAweyZMkSGjRowHvvvce+ffuYMmUKJ06cYNKkSZnaR0aGDx9Ozpw56datGxcuXGDmzJkMHTqUcePGATBgwACGDRuGk5MTnTt3Bv4vkLyI11ZGzpw5Q8+ePXnrrbeMr4/+/ftTvnx5SpcuDdwLNe+++y4pKSl06tSJbNmysWjRogxHCpcuXUr//v0JCgqib9++3L59m/nz59O6dWuWLFliMuqanJxMx44dqVSpEmFhYWTNmvWhdVaqVIlff/2Vv//+m4CAAOBe0PXz88Pf35+4uDiOHj1KmTJljOtKlChBrly5jPv4+++/OXPmDBERETg6OlKvXj2WL19ufO4fVLBgQXx9ffn9998JDg4G4H//+x9xcXE0atSI2bNnZ7jd476HT58+zcmTJ2nRogXOzs4PPecXJa221NRUzp07x+jRo3F1dX1s6F61ahV37tzhnXfewdXVlX379jFnzhwuX77M+PHjje26d+/O8ePHadu2LQULFuTatWts2bKFS5cuPXTUXSyIQeRfIjY21uDp6Wno0qXLI9t17tzZ4OnpaYiLizMYDAbD+PHjDZ6enobOnTubtAsPDzd4enoaDh06ZDAYDIYZM2YYPD09DTExMQ/d99KlSw1lypQx7Nq1y2T5/PnzDZ6enoY9e/YYl3l6ehrKlCljOHbsmEnbTZs2GTw9PQ1//PGHyfIPP/zQUKdOnSc+1qFDhwyenp6G8PBwk3a9e/c2eHp6GsaPH//Q8zEYDIYFCxYYPD09DUeOHDFZ3qhRI8O7775rfPzGG28YOnXq9Mh9PQlPT8+Hfv3222/GdikpKYZ33nnHUK1aNcO1a9cMQ4YMMZQrV86wb98+k/3VqlXL4OnpaVi9erVxWVxcnKF69eqGpk2bGpdNmjTJ4Ovrazh16pTJ9qNHjzaULVvWcPHiRYPBYDBs27bN4OnpaRg2bFi62lNTU43/9/X1NYSFhaVrM2DAAEP16tUN165dM1neq1cvQ6VKlQy3b982GAwGw48//mjw9PQ0rFixwtgmISHBUK9ePYOnp6dh+/btD30O4+LiMvU9kSbttfLZZ5+ZLB85cqTB09PTsG3bNuOyh712atWqZXK+ixcvNnh6eho6dOhg8rxEREQYypYta4iNjTUua9y4saFt27bp9vm0r6207+0HpdV07tw5k7o9PT1Nvp9iYmIM3t7ehpEjRxqXffHFFwZPT0/D33//bdKuUqVKJvu8deuWoXLlyoaBAweaHDsqKspQqVIlk+VhYWEGT09Pw+jRozN1XseOHTN4enoaJk2aZDAYDIakpCSDr6+vYcmSJQaDwWCoVq2aYc6cOQaD4d5roGzZsunqGDp0qCE4ONjYJ5s3bzZ4enoa/vnnnwyfq3379hnmzJlj8PPzM742e/ToYWjXrp3x+XuwjzLzPbxu3TqDp6enYcaMGZk69+3btxs8PT0NK1euzHD9kCFDMuzzB6U95w9+1ahRw3DgwIEMj3n/91rac3C/KVOmGLy8vAwXLlwwGAwGw82bNw2enp6G77//PlPnJpZH0yHkXyM+Ph6A7NmzP7Jd2vq09mnatGlj8rht27bAvdEOgJw5cwKwfv36h771uWrVKkqWLEmJEiW4du2a8SvtQyoPXmKnSpUqlCpVymRZ1apVyZUrFytWrDAuu3nzJlu3bjX5YEtmj5U26p321nKa+98Cf5R69ephb29vUs/Ro0c5fvy4ST05c+bk2LFjnD59OlP7zYw6deowY8aMdF9po19wb77eyJEjSUhI4MMPP2TevHl06tQJHx+fdPvLkyePyYeJnJ2dadq0Kf/88w9RUVHAvee1UqVK5MyZ0+R5rVatGikpKezatQu49wFMGxubdCPkADY2No88L4PBwJo1a6hduzYGg8HkOEFBQcTFxXHw4EHg3uvPw8PDOOIOkC1bNuPI8qPcunULePz3RJq018p7771nsvz99983Wf800ka901SuXJmUlBQuXLjw2G1fxGsrI6VKlTJ5F8nNzY3ixYtz7tw547KNGzfi6+tLhQoVTNo9OCVg69atxMbG0rhxY5P+tbW1pWLFihlebuudd97JVJ0lS5bE1dXVONf38OHDJCQk4OfnB4Cfn5/xHarIyEhSUlJM5gMnJyezYsUKXnvtNWOfVK1aldy5c7Ns2bKHHve1117j7t27/Pnnn9y6dYsNGzY8dirE476Hn/Q1+jxlyZLFWM/06dMZOnQoTk5OdOrUiVOnTj1y2/tH6hMSErh27Rp+fn4YDAb++ecfYxsHBwd27tzJzZs3X+i5yIuh6RDyr/GwcPugh4XlokWLmjwuUqQItra2xrlbjRo14qeffmLgwIGMGTOGwMBA6tWrR8OGDbG1vff34pkzZzhx4gSBgYEZHjsmJsbkcUZvh9nb21O/fn1+++03EhMTcXR0ZM2aNSQlJZmEzswe68KFC9ja2hrfhk9TokSJDLd7kJubG1WrVmXlypV8/PHHwL2pEPb29iaBskePHnTt2pUGDRrg6elJUFAQb775pvEt2aeRL18+qlWr9th2RYoUoVu3bowaNQpPT0+6du2aYbuiRYumC6jFihUD7j1PHh4enDlzhiNHjjz0eU17+/Ts2bPkyZMHV1fXzJ/QffuIjY1l4cKFLFy48JHHuXDhQoZ1Z+YKGWlvLz/ueyLNw14rHh4e5MyZM1OB9WEKFChg8jjtj8rY2NjHbvsiXlsZyZ8/f7plLi4uJgHm4sWLVKxYMV27B/sjLbA/7I/NB9/6t7e3J1++fJmq08bGBj8/P3bv3k1qaip//fUXuXPnNv4M8/PzY+7cuQDGMHx/CN6yZQvXrl2jQoUKnDlzxrg8ICCA33//nU8++cT4M+1+bm5uBAYG8ttvv3Hnzh1SUlJo0KDBI2t93Pfwk75Gnyc7O7t0tQUHB1O/fn3Gjh37yGuoX7x4kfHjx/PHH3+kC7hpwd7R0ZG+ffvy5ZdfUr16dSpWrMirr75K06ZN8fDweP4nJM+dQrD8a+TIkQMPDw+OHDnyyHZHjhwhb968j51/9mDoyJo1K3PnzmXHjh1s2LCBTZs2sWLFChYuXMgPP/yAnZ0dqampeHp6ZvjBNiDdL7mHzftr3LgxCxcu5H//+x9169Zl1apVlChRwuSX/pMe61k0btyYTz/9lEOHDlG2bFlWrlxJ1apVTT58WKVKFdauXcv69evZsmULP//8MzNnzmTIkCG8/fbbz62Wh0n7wM7Vq1e5cePGU/+SSU1NpXr16nzwwQcZrk8Lzc8i7Z2EN954g2bNmmXYJjPXOn0cZ2dn8uTJ88TXx37cSPajpKSkZLg8o1AF90bFH+dpX1sPO4+H1Xj/h6GeVdp5jRo1KsPX4oPHcnR0fOhzlJFKlSrx559/cvToUeN84DR+fn6MGjWKK1eusGfPHvLkyWNyNZy00d60P2oftHPnTpNLrN3v9ddf5/PPPyc6OpqaNWsa/5h5Wml/jB89ejRT7dPmXj/s2ta3b99+pis55MuXj+LFixvf8clISkoK7733Hjdv3uSDDz6gRIkSODk5ceXKFfr372/yTmGHDh2oXbs269atY/PmzXzzzTdMnTqVmTNnUq5cuaeuU14OhWD5V6lVqxaLFi1i9+7dGX44bvfu3Vy4cIFWrVqlW3fmzBmTXxRnzpwhNTXVZLTW1taWwMBAAgMD+fTTT5k8eTJff/01O3bsoFq1ahQpUoTDhw8TGBj4TEGiSpUqeHh4sGLFCuMH2R78wEpmj1WwYEFSU1M5e/asyejvyZMnM11P3bp1GTRokHFKxOnTp9NdGB8wXpu5RYsWxMfH07ZtWyZMmPDCQ/D8+fPZsmULvXr1YsqUKQwaNIjvvvsuXbszZ85gMBhMnq+0EbuCBQsC957XhISEx45AFylShM2bN3Pjxo0nHg12c3Mje/bspKamPvY4BQsW5OjRo+nqftzbtWlq1arFwoUL2bt3r0lQetixUlNTOXPmDCVLljQuj46OJjY21vgcwb0R0gdHcRMTE43TSp7Go17HT/Paun+0+f6wdvHixaeusUCBAiajp2ke7I+0nyW5c+fO1LsZT+r+6wX/9ddfJiPO3t7eODo6smPHDvbt20fNmjWN6xISEvjjjz9o1KhRhqO4w4cPZ/ny5Q8NwfXq1WPw4MFERkby9ddfP/N5FC9enOLFi7N+/Xri4+MfOy0i7R2Fh73+T506le5dhyeVkpJCQkLCQ9cfPXqU06dP8+WXX9K0aVPj8oddraRIkSK8//77vP/++5w+fZqmTZvyww8/MHr06GeqU148zQmWf5WOHTuSNWtWBg8ezPXr103W3bhxg8GDB5MtW7YMR/nS3j5Mk3bpr7RfIBldB7Ns2bIAxstHvfbaa1y5coVFixala3vnzp1H/mC9n62tLQ0bNuTPP/9k2bJlJCcnp7vQfWaPlVb/g5/enjlzZqZqgXthIigoiJUrV/L777/j4OCQ7uYPDz7f2bNnp0iRIiaX1oqLi+PEiRPExcVl+tiPc+7cOePVITp37kxYWBh//PFHhpe2unr1qsmdtm7dusXSpUspW7ascbTutddeY+/evWzatCnd9rGxscbrldavXx+DwZDh5ePuH910cnJKFxbt7Oxo0KABq1evznAE7P5P09esWZOrV6+a3CHr9u3bGfZ7Rj744AOcnJwYOHAg0dHR6dafPXvW+FpI+9T/g6+NGTNmmKyHeyHvwTuILVq06KGjrJmRLVu2DKdHZOa1lZG0aR33j+olJCRk+NrIrODgYCIjI9m3b59x2bVr11i+fLlJuxo1auDs7MyUKVNISkpKt59nvU27t7c3WbJkYfny5Vy5csXkDxxHR0fKly/PvHnzSEhIMJkKsXbtWhISEmjTpg0NGzZM91WrVi3WrFnz0Oc2e/bshIeH0717d2rXrv1M55CmR48e3Lhxg4EDB2Z4PeDNmzfz559/Avfm9ZctW5bly5ene60cOHCAv//+2yT0P6lTp05x6tSpR061SRuxv//73GAwMGvWLJN2t2/fTneZzSJFipA9e/ZMX+JQzEsjwfKvUqxYMUaOHMknn3xCkyZNeOutt0zuGHf9+nXGjh2bbs4jwPnz5+ncuTM1atQgMjLSeEmxtB+GkyZNYvfu3QQHB1OwYEFiYmKYN28e+fLlM/6SefPNN1m5ciWDBw9mx44d+Pv7k5KSwsmTJ1m1ahXff/99hh/Yyshrr73G7NmzGT9+PJ6eniYjc09yrLJly/L6668zb9484uLi8PPzY/v27RmOZj1Ko0aN+OSTT5g3bx5BQUHp3gZt3Lgxr7zyCuXLl8fV1ZX9+/ezevVq4wcM4d4v4E8//ZQRI0Zk6q5gp0+f5tdff0233N3dnerVq2MwGBgwYABZs2YlPDwcgJCQENasWcMXX3xBYGCg8a5PcO/18dlnn7F//35y587N4sWLiYmJYcSIEcY2HTt25I8//qBz5840a9aM8uXLc/v2bY4ePcrq1atZv369cZ70m2++yezZszlz5gw1atQgNTWVPXv2EBAQYDzv8uXLs23bNmbMmEGePHkoVKgQFStWpE+fPuzYsYOWLVvy9ttvU6pUKW7evMnBgwfZtm0bO3fuBO59oGzu3LmEhYVx8OBBPDw8+PXXXx95Ca37FSlShNGjR9OrVy8aNWpkvGNcYmIie/fuZdWqVca+KFOmDM2aNWPhwoXExsZSpUoV9u/fz5IlS6hbt67J6ODbb7/N4MGD6d69O9WqVePw4cNs3rzZ5DJcT6p8+fLMnz+fb7/9lqJFixrnoGbmtZWR6tWrU6BAAT777DNOnjyJnZ0dixcvJleuXE89GvzBBx/w66+/8sEHH/Duu+8aL5FWoEABk6lYzs7OhIeH069fP5o3b06jRo1wc3Pj4sWLbNy4EX9//2e6/bejoyM+Pj7s3r0bR0dHvL29Tdb7+fnxww8/AKbzgZcvX46rq+tD3xWoXbs2ixYtYsOGDdSvXz/DNg+bwpORx30Pw72fLUeOHGHy5Mn8888/vP7668Y7xm3atIlt27YxZswY47b9+/fngw8+oGnTpjRr1ow8efJw4sQJFi1ahIeHR4bvUmUkOTnZWJvBYOD8+fMsWLCA1NRUPvroo4duV6JECYoUKcKXX37JlStXcHZ2ZvXq1elC+enTp+nQoQMNGzakVKlS2NnZsW7dOqKjo2ncuHGmahTzUgiWf53XXnuNEiVKMHXqVH7++Wfj29UBAQGEhobi6emZ4Xbjxo3jm2++YcyYMdjb29O2bVuTmzDUrl2bCxcusHjxYq5fv06uXLl45ZVX6N69Ozly5ADujRBMmjSJH3/8kV9//ZW1a9eSLVs2ChUqRLt27Z7odr/+/v7kz58/w9udPumxIiIiyJUrF8uXL2f9+vUEBAQwdepUk5G9x6lduzZZs2YlPj4+w3ratWvHH3/8wZYtW0hMTKRAgQJ8/PHHdOzYMdPHeNCWLVsyfIvxlVdeoXr16syePZudO3cyYcIEk/nJX3zxhXHu4tSpU43LixUrxueff86oUaM4deoUhQoV4uuvv6ZGjRrGNtmyZWP27NlMmTKFVatWsXTpUpydnSlWrJhJXwOMGDECLy8vfv75Z0aNGkWOHDnw9vY2CRj9+/dn0KBBjBs3jjt37tCsWTMqVqyIu7s7P/30E5MmTWLt2rXMnz8fV1dXSpUqZXKjhGzZsvHjjz8ybNgw5syZQ9asWWnSpAk1a9Z86LzlB9WpU4dly5Yxffp01q9fz/z583F0dDTevOP+K00MHz6cQoUKsWTJEtatW4e7uzuhoaHproLRsmVLzp8/z88//8ymTZuoVKkSM2bMMF7f+Gl89NFHXLx4ke+//574+HheeeUVAgMDn/q15eDgwMSJExkyZAjffPMNHh4etG/fnpw5cz50Lv3j5MmTh1mzZjF8+HCmTp2Kq6srISEh5MmTx+Qa0gBNmjQhT548TJ06lenTp5OYmEjevHmpXLnyc7k1dKVKldi9ezfly5dPd9tif39/fvjhB7Jnz278Qz4mJoZt27bRuHHjh85/DgwMJFu2bCxbtuyhIfhJPO57OE2vXr2oWrUqs2fPZv78+dy8eZOcOXNSsWJFvv32W+rUqWNsW7VqVebOnct3333H7NmziY+PJ3fu3Lz++ut0796d3LlzZ6q2xMREk5/xzs7O+Pj48NVXXz30g7Fw73U1efJkhg8fzpQpU8iSJQv16tWjTZs2Jnegy5cvH40bN2bbtm0sW7YMOzs7SpQowbhx4x77gUKxDDaGzHxqQUTEwtWuXZvSpUszZcoUc5ciIiL/ApoTLCIiIiJWRyFYRERERKyOQrCIiIiIWB3NCRYRERERq6ORYBERERGxOgrBIiIiImJ1FIJFRERExOroZhlPICrq+d0K1pLZ2trg5pada9fiSU3VlHFzU39YHvWJ5VGfWBb1h+Wxpj7x8Mjx+EZoJFgyYGtrg42NDba2NuYuRVB/WCL1ieVRn1gW9YflUZ+kpxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6igEi4iIiIjVUQgWEREREaujECwiIiIiVkchWERERESsjkKwiIiIiFgdhWARERGRf7m33mrCokXzzF3Gc/Myzsf+he5dntn7I/8wy3GXj3nTLMcVERF5WV7279gf+td+qu2uXLnM9OlT2LFjGzdv3iB3bndq1HiV9977ABcX1+dbpBVRCBYRERGxUBcunKdz5/cpXLgI4eFfkD9/QU6dOsG3337D9u1bmTp1Bjlzurz0ulJSUrCxscHW9t87qUAhWDLUcmEXsxx3Uu1RZjmuiIiIJRo7dhQODg58/fVEsmTJCkC+fPnw9PSiVaumTJ36LX37fgpAQkICgwcPYMuW/+HsnIN27d6jRYuWABgMBiZMmMBPP/3MtWsx5MzpQq1adfj4408ASExMZOrUb1m3bjW3bsVRvHhJunTpjr9/ZQBWrFjO+PFjGDhwCJMnT+TcubP07h3GN9+M5tdfV5MjRw5jzePGjebkyeOMHz8ZgL//jmTKlIkcPnwIV1dXatZ8ldDQbmTLlg2A69evMWLEMHbv3knu3Ln58MOXk0H+vfFdRERE5D8sNvYmO3duo1mzt4wBOE3u3O7Uq/ca69evxWAwADBv3mxKlfLkhx/m0rZte8aPH8OuXdsB+PPP9fz444+EhX3G/PlLGDFiNCVKlDLu7+uvR3Hw4D6GDIlg5swF1KpVl759e3Du3Fljmzt37jB37kzCwgYye/ZC6td/DWfnHGzcuN7YJiUlhT/+WEv9+g2BeyPZfft259VXazNz5nyGDIlg375Ivv76/wa9vvginKtXrzB+/GSGDfuSJUt+4vr1a8//CX2AQrCIiIiIBTp37hwGg4GiRYtnuL5YsWLExcVy48Z1AHx8KtKuXQeKFCnKW2+F8OqrtVm48N6Hyy5fvoy7uzuvvPIK+fLlo1w5b954o5lx3YoVyxk27EsqVvSjYMFCtG7dDh8fX1asWG48XnJyMr1798fHpyJFihQjW7Zs1KlTn7VrVxvb7Nmzi1u34ggOrgPA7NkzqFevIS1btqZw4SL4+FSkZ89PWLXqd+7evcvZs2fYvn0rYWGf4e3tQ5kyZenffxB37959Ic/p/TQdQkRERMSCpY30Po63t4/J4/LlK/DTT/MBqFOnLj/9NJ/mzd8gICCQqlWrU716Dezt7Tl58jgpKSm8805zk+0TExNxcfm/+cYODg6UKlXapE39+g0JDX2P6Ogo3N09WLNmJYGB1Y3TI44fP8aJE8dYu3aVyfmkpqZy6dJFzp07g52dHV5eZY3rixYthrNzDl40s4fgefPmMX/+fC5cuABA6dKl6dq1K8HBwQC0a9eOnTt3mmzTqlUrhg4danx88eJFwsPD2bFjB05OTjRt2pQ+ffpgb/9/p7djxw5GjhzJsWPHyJ8/P126dKF5c9POFhEREbEUhQoVwsbGhjNnTgG10q0/ffo0OXLkxNU112P3lTdvPlatWsWaNX+wY8d2xo4dyfz5s5k4cSq3bydgZ2fH9OmzsbW1M9kubd4uQJYsWbCxsTFZX7ZseQoUKMS6datp1uwt/ve/DXz22WDj+tu3E3jzzea89VZIhjWdO3fmsbW/KGYPwfny5aNv374ULVoUg8HA0qVL+eijj1iyZAmlS9/7a6Nly5b06NHDuM39HZKSkkJoaCju7u4sWLCAq1evEhYWhoODA7179wbuvZ0QGhpKSEgIo0ePZtu2bQwcOBAPDw9q1Kjxck9YREREJBNcXFypUiWAJUt+plWr1ibzgmNiolm7diUNGzY2BtODB/ebbH/w4H6KFi1mfJw1a1Zq1AgmMLAGzZu/TevWb3HixHFKl/YiJSWF69evU7Gi3xPXWb9+Q9asWYWHR15sbW0IDAwyrvP0LMOpU6coVKhwhtsWLVqMlJQUjhw5RNmy5QE4e/Y0t27FPXEdT8rsc4Jr165NcHAwxYoVo3jx4vTq1QsnJyciIyONbbJmzYqHh4fxy9nZ2bhu8+bNHD9+nK+++oqyZcsSHBxMz549mTt3LomJiQAsWLCAQoUK0b9/f0qWLEnbtm1p0KABP/7440s+WxEREZHM69WrH0lJifTu3Z3IyL+4cuUy27dvpVevj3B3z0OnTl2Nbffv/5u5c2dy9uwZFi9exIYN63n77XcA+O23Zfz000+cOHGcCxfOs3r1SrJkyUK+fPkoUqQo9eu/xvDhg9m48Q8uXrzAP/8cYPbsGWzduvmxNdav/xpHjx5m1qwfePXVOjg6OhrXtWnTngMH/mbs2C85duwI586dZdOmDYwd+yUARYoUIyCgGl99FcHBgwc4fPgQI0cOJ0uWLM/1ecyI2UeC75eSksKqVatISEjAz+///hJZvnw5y5Ytw8PDg1q1atG1a1fjaHBkZCSenp64u7sb2wcFBREeHs7x48cpV64ckZGRBAYGmhwrKCiIiIiIJ6rP1tYGW1ubxzeUp2Zvb/a/yyyOnZ2tyb9ifuoTy6M+sSz/lv6YNbCuuUt4rOLFizFjxhymTZvCoEGfEht7k9y53alZ81U++KCTyc0yWrdux9Gjh5kxYxrZszvTo0dvqlevDoCLS07mzJnJ8eMnSE1NoWTJUowePY7cud0AGDQonBkzvmfixHFERV3F1dWV8uV9qFGjJvb2tsb8k9Hv6WLFilKunDf//HOA3r37mrQpU8aL7777nsmTJ/HRRx9iMBgoWLAQdevWN7YbNCiciIihdO/eCTc3N0JDuzJlynfY2tq80FxgY8jsbOsX6MiRI4SEhHD37l2cnJwYM2aMcU7wwoULKVCgAHny5OHIkSOMHj2aChUqMHHiRAA+//xzLl68yPTp0437u337Nr6+vkydOpXg4GAaNGhA8+bNCQ0NNbbZuHEjnTp14u+//yZrVtPLjjyMwWBINxfmRWvS59eXerw02V5Z9fhGL8CiVt+Z5bgiIiJiXSxiJLh48eIsXbqUuLg4Vq9eTVhYGHPmzKFUqVK0atXK2M7LywsPDw86dOjA2bNnKVKkyEut89q1eI0Ev2DXr8ebuwSLY2dnS86c2YiNvU1KSqq5yxHUJ5ZIfWJZ1B+Wx5r6JFeu7JlqZxEh2NHRkaJFiwLg7e3N/v37mTVrlskVINJUrFgRgDNnzlCkSBHc3d3Zt2+fSZvo6GgAPDw8AHB3dzcuu7+Ns7NzpkeBAVJTDaSmmn3g/D8tOfm//Y35LFJSUvX8WBj1ieVRn1gW9YflUZ/8H4ucrJOammr8UNuDDh06BPxfwPX19eXo0aPExMQY22zduhVnZ2dKlSplbLN9+3aT/WzduhVfX98XUL2IiIiIWDqzh+AxY8awa9cuzp8/z5EjRxgzZgw7d+6kSZMmnD17lkmTJnHgwAHOnz/P+vXrCQsLo0qVKpQpUwa49wG3UqVK0a9fPw4fPsymTZsYN24cbdq0MX46MSQkhHPnzjFq1ChOnDjB3LlzWblyJR06dDDjmYuIiIiIuZh9OkRMTAxhYWFcvXqVHDly4OXlxfTp06levTqXLl1i27ZtzJo1i4SEBPLnz0/9+vXp2vX/LgdiZ2fH5MmTCQ8Pp1WrVmTLlo1mzZqZXFe4cOHCTJkyhREjRjBr1izy5cvH8OHDdY1geWLvj/zDLMddPuZNsxxXRETkv8rsIfhRlynLnz8/c+bMeew+ChYsyLRp0x7ZJiAggKVLlz5peSIiIiLyH2T26RAiIiIiIi+b2UeCReTxWi7sYrZjT6o9ymzHFhEReVE0EiwiIiIiVkcjwSIiImKVPvqj30s9nt5Ze7xu3TpRurQXPXv2eeHHUggWERERsVBffBHOypW/pVv+yiuBjB07wQwVpfcyg+vzpBAsIiIiYsECAqoxYMAgk2UODo5mqua/QyFYREREnjt9oPf5cXR0IHdu93TL//prN717d+Obb76jYkU/AObOncn8+XOYNWsBbm656datEyVKlMTW1oZVq1ZgZ2dP06Yt+OCDztjY2ACQmJjI1Knfsm7dam7diqN48ZJ06dIdf//KxmPt2xfJ1KnfcujQQRwcHClXrjzh4RFMmDCWyMi/iIz8i59+mg/ATz8tI3/+Apw8eZxJk8azb99esmbNxiuvBNC9ex9cXV0BuH37NqNHj+B///sTJycnQkLaveBn0pRCsIiIyH+YuW7yk+0VsxzWqvj7V6Zly3cYNmwQP/44n4sXz/P995MZNmwkbm65je1WrvydN954k59++okdO/YwcuRw8ubNxxtvNAPg669Hcfr0SYYMicDd3YONG/+kb98ezJy5gMKFi3Ds2BE+/rgrjRq9Qc+efbGzs2Pv3t2kpqbSs2dfzp07S/HiJfngg1AAXF1zERcXR48eXWjSpCk9evTm7t07fPfdBAYN6s/48ZMBmDTpGyIj/2LEiDHkyuXGlCmTOHr0CKVLe72U508hWEREnivdWVHk+dq6dTP16pne5bZdu/d49933+fDDruzatYNRo77g5MkTNGz4OkFBwSZt8+bNy8cf98XNzZlcufJy7NgxFi2axxtvNOPy5cusWLGcxYt/w93dA4DWrduxY8c2VqxYTmjoR8ydOwsvr7L07dvfuM8SJUoa/29vb0/WrFlNRqsXL16Ip6cXoaEfGZd9+ukgmjdvzNmzZ3B39+D333/l88+HUbnyvb+YBg4Mp1mzRs/viXsMhWARkadgrrd6/2tv84rI4/n5VaJv309NluXMmRMABwcHBg0aTocO75A3bz569Oidbvty5byNUx8AvL19WLBgDikpKZw8eZyUlBTeeae5yTaJiYm4uLgAcPz4UWrVqvtENR8/foy//tqdLrwDXLhwnrt375KUlES5ct73nZMLRYoUfaLjPAuFYBERERELli1bNgoVKvzQ9QcO7AMgNjaW2NibZMuWLdP7vn07ATs7O6ZPn42trV264wI4OmZ54ppv375N9eo16NKlR7p1uXO7c/78uSfe5/Omm2WIiIiI/EtduHCe8ePH0q/fZ5Qr580XX4STmppq0uaffw6aPD548ACFCxfBzs6O0qW9SElJ4fr16xQqVNjkK216Q6lSpdm9e+dDa3BwcCA1NcVkmaenF6dOnSRfvvzp9pstWzYKFiyEvb09//xzwLhNbGws586dfdanJNM0EiwiIv8JmqIi/1WJiUnExESbLLOzsydHjhwMHfo5AQFVadz4DQICqtG+fSsWLJhD69bvGtteuXKZcePG0L59W3bt2svixQv56KOPAShSpCj167/G8OGD6dbtY0qX9uLGjevs2bOLkiVLU61aEG3bdqB9+xBGjx5J06YtcHBw4K+/dlOrVl1cXV3Jl68A//xzgEuXLpItmxM5c+akRYuWLF++lPDwz2jT5l1y5nTh/PlzrF+/hrCwgTg5OfH662/y7bff4OLiQq5cuZg69VtsbF7e+KxCsIiIiFilf8sfMDt2bOXNNxuaLCtSpCj16jXk8uVLjBr1NQDu7u706/cZ4eGfUaVKVUqX9gSgYcPG3L17l7fffhtbW1veeiuEN9/8vznAAwYMZubM6UycOI6oqKu4uLhSvrwP1arVMB5r7NiJTJ06iU6d2uPomIVy5bypW7cBAO+805Yvvginbdu3uXv3rvESad99N53vvptAr17dSEpKJF++/AQEBGJrey/odu3ak9u3EwgL64WTU3ZCQtpw69atF/58prExGAyGl3a0f7moqLiXfkzzXdpmlVmOa+k/kKytP8Dy+8Qc7O1tCV3T1yzH/jf0h7V9n1h6n1hbf4Dl98nLlHY3tz59PiFXruxcvx5PcnLq4zf8F/PwyJGpdpoTLCIiIiJWR9MhRORfTTcCEBGRp6EQLCIiIvIfNXHiVHOXYLE0HUJERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6igEi4iIiIjVUQgWEREREauj6wSLiIiIWIGWC7uY5biWehtrhWARERGRl0h3urQMmg4hIiIiIlZHIVhERERErI7ZQ/C8efNo0qQJ/v7++Pv706pVKzZu3Ghcf/fuXYYMGUJAQAB+fn50796d6Ohok31cvHiRTp06UbFiRQIDA/nyyy9JTk42abNjxw6aNWuGt7c39erV45dffnkp5yciIiIilsfsIThfvnz07duXX375hcWLF1O1alU++ugjjh07BkBERAR//vkn48aNY/bs2Vy9epVu3boZt09JSSE0NJSkpCQWLFjAyJEjWbJkCePHjze2OXfuHKGhoQQEBPDrr7/Svn17Bg4cyKZNm176+YqIiIiI+Zk9BNeuXZvg4GCKFStG8eLF6dWrF05OTkRGRhIXF8fixYvp378/gYGBeHt7ExERwd69e4mMjARg8+bNHD9+nK+++oqyZcsSHBxMz549mTt3LomJiQAsWLCAQoUK0b9/f0qWLEnbtm1p0KABP/74o/lOXERERETMxqKuDpGSksKqVatISEjAz8+PAwcOkJSURLVq1YxtSpYsSYECBYiMjMTX15fIyEg8PT1xd3c3tgkKCiI8PJzjx49Trlw5IiMjCQwMNDlWUFAQERERT1Sfra0NtrY2z3aS8kj29mb/u0weoD6xLOoPy6M+sTzqE8tiqf1hESH4yJEjhISEcPfuXZycnJg0aRKlSpXi0KFDODg4kDNnTpP2uXPnJioqCoDo6GiTAAwYHz+uza1bt7hz5w5Zs2bNVJ1ubtmxsVEIfpFy5cpu7hLkAeoTy6L+sDzqE8ujPrEsltofFhGCixcvztKlS4mLi2P16tWEhYUxZ84cc5eVzrVr8RoJfsGuX483dwnyAPWJZVF/WB71ieVRn1iWl90fmQ3dFhGCHR0dKVq0KADe3t7s37+fWbNm8dprr5GUlERsbKzJaHBMTAweHh7AvRHdffv2mewv7eoR97d58IoS0dHRODs7Z3oUGCA11UBqquHJT1AyLTk51dwlyAPUJ5ZF/WF51CeWR31iWSy1PyxykkZqaiqJiYl4e3vj4ODAtm3bjOtOnjzJxYsX8fX1BcDX15ejR48SExNjbLN161acnZ0pVaqUsc327dtNjrF161bjPkRERETEupg9BI8ZM4Zdu3Zx/vx5jhw5wpgxY9i5cydNmjQhR44ctGjRgpEjR7J9+3YOHDjAgAED8PPzMwbYoKAgSpUqRb9+/Th8+DCbNm1i3LhxtGnTBkdHRwBCQkI4d+4co0aN4sSJE8ydO5eVK1fSoUMH8524iIiIiJiN2adDxMTEEBYWxtWrV8mRIwdeXl5Mnz6d6tWrAzBgwABsbW3p0aMHiYmJBAUFMXjwYOP2dnZ2TJ48mfDwcFq1akW2bNlo1qwZPXr0MLYpXLgwU6ZMYcSIEcyaNYt8+fIxfPhwatSo8dLPV0RERETMz+wh+HGXKcuSJQuDBw82Cb4PKliwINOmTXvkfgICAli6dOnTlCgiIiIi/zFmnw4hIiIiIvKyKQSLiIiIiNVRCBYRERERq6MQLCIiIiJWRyFYRERERKyOQrCIiIiIWB2FYBERERGxOgrBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhERERGroxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6igEi4iIiIjVUQgWEREREaujECwiIiIiVkchWERERESsjkKwiIiIiFgdhWARERERsToKwSIiIiJidRSCRURERMTqKASLiIiIiNVRCBYRERERq6MQLCIiIiJWRyFYRERERKyOQrCIiIiIWB2zh+ApU6bQokUL/Pz8CAwMpGvXrpw8edKkTbt27fDy8jL5GjRokEmbixcv0qlTJypWrEhgYCBffvklycnJJm127NhBs2bN8Pb2pl69evzyyy8v/PxERERExPLYm7uAnTt30qZNG3x8fEhJSWHs2LF07NiR33//HScnJ2O7li1b0qNHD+PjbNmyGf+fkpJCaGgo7u7uLFiwgKtXrxIWFoaDgwO9e/cG4Ny5c4SGhhISEsLo0aPZtm0bAwcOxMPDgxo1ary8ExYRERERszN7CJ4+fbrJ45EjRxIYGMjBgwepUqWKcXnWrFnx8PDIcB+bN2/m+PHjzJgxA3d3d8qWLUvPnj0ZPXo03bp1w9HRkQULFlCoUCH69+8PQMmSJdmzZw8//vijQrCIiIiIlTF7CH5QXFwcAC4uLibLly9fzrJly/Dw8KBWrVp07drVOBocGRmJp6cn7u7uxvZBQUGEh4dz/PhxypUrR2RkJIGBgSb7DAoKIiIiItO12draYGtr87SnJplgb2/2GTryAPWJZVF/WB71ieVRn1gWS+0PiwrBqampRERE4O/vj6enp3H566+/ToECBciTJw9Hjhxh9OjRnDp1iokTJwIQHR1tEoAB4+OoqKhHtrl16xZ37twha9asj63PzS07NjYKwS9SrlzZzV2CPEB9YlnUH5ZHfWJ51CeWxVL7w6JC8JAhQzh27Bjz5s0zWd6qVSvj/728vPDw8KBDhw6cPXuWIkWKvLT6rl2L10jwC3b9ery5S5AHqE8si/rD8qhPLI/6xLK87P7IbOi2mBA8dOhQNmzYwJw5c8iXL98j21asWBGAM2fOUKRIEdzd3dm3b59Jm+joaADjPGJ3d3fjsvvbODs7Z2oUGCA11UBqqiFTbeXpJCenmrsEeYD6xLKoPyyP+sTyqE8si6X2h9knaRgMBoYOHcratWuZOXMmhQsXfuw2hw4dAv4v4Pr6+nL06FFiYmKMbbZu3YqzszOlSpUyttm+fbvJfrZu3Yqvr+9zOhMRERER+bcwewgeMmQIy5YtY8yYMWTPnp2oqCiioqK4c+cOAGfPnmXSpEkcOHCA8+fPs379esLCwqhSpQplypQB7n3ArVSpUvTr14/Dhw+zadMmxo0bR5s2bXB0dAQgJCSEc+fOMWrUKE6cOMHcuXNZuXIlHTp0MNepi4iIiIiZmH06xPz584F7N8S434gRI2jevDkODg5s27aNWbNmkZCQQP78+alfvz5du3Y1trWzs2Py5MmEh4fTqlUrsmXLRrNmzUyuK1y4cGGmTJnCiBEjmDVrFvny5WP48OG6PJqIiIiIFTJ7CD5y5Mgj1+fPn585c+Y8dj8FCxZk2rRpj2wTEBDA0qVLn6Q8EREREfkPMvt0CBERERGRl00hWERERESsjkKwiIiIiFgdhWARERERsToKwSIiIiJidRSCRURERMTqKASLiIiIiNVRCBYRERERq6MQLCIiIiJWRyFYRERERKyOQrCIiIiIWB2FYBERERGxOgrBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhERERGroxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6jxVCK5Tpw6HDx/OcN3Ro0epU6fOMxUlIiIiIvIiPVUIvnDhAomJiRmuu3PnDpcvX36mokREREREXiT7zDa8e/cut2/fxmAwAHDr1i1u3LiRrs26devIkyfPcy1SREREROR5ynQInjZtGpMmTQLAxsaGjh07PrRtt27dnr0yEREREZEXJNMhuG7duhQsWBCDwcCAAQPo0qULRYoUMWnj4OBAyZIlKVu27HMvVERERETkecl0CC5TpgxlypQB7o0EBwcH4+bm9sIKExERERF5UTIdgu/XrFmz512HiIiIiMhL81Qh+M6dO3z77besXr2ay5cvZ3iliEOHDj1zcSIiIiIiL8JTheAhQ4bw22+/8frrr1OyZEkcHByeuoApU6awZs0aTp48SdasWfHz86Nv376UKFHC2Obu3buMHDmSFStWkJiYSFBQEIMHD8bd3d3Y5uLFi4SHh7Njxw6cnJxo2rQpffr0wd7+/05xx44djBw5kmPHjpE/f366dOlC8+bNn7p2EREREfl3eqoQ/OeffxIWFkbbtm2fuYCdO3fSpk0bfHx8SElJYezYsXTs2JHff/8dJycnACIiIti4cSPjxo0jR44cDBs2jG7durFgwQIAUlJSCA0Nxd3dnQULFnD16lXCwsJwcHCgd+/eAJw7d47Q0FBCQkIYPXo027ZtY+DAgXh4eFCjRo1nPg8RERER+fd4qhBsZ2dHsWLFnksB06dPN3k8cuRIAgMDOXjwIFWqVCEuLo7FixczevRoAgMDgXuhuFGjRkRGRuLr68vmzZs5fvw4M2bMwN3dnbJly9KzZ09Gjx5Nt27dcHR0ZMGCBRQqVIj+/fsDULJkSfbs2cOPP/6Y6RBsa2uDra3NczlvyZi9ve7kbWnUJ5ZF/WF51CeWR31iWSy1P54qBL/zzjv8+uuvBAUFPe96iIuLA8DFxQWAAwcOkJSURLVq1YxtSpYsSYECBYwhODIyEk9PT5PpEUFBQYSHh3P8+HHKlStHZGSkMUTf3yYiIiLTtbm5ZcfGRiH4RcqVK7u5S5AHqE8si/rD8qhPLI/6xLJYan88VQjOmjUre/bsISQkhMDAQHLmzGmy3sbGhg4dOjzxflNTU4mIiMDf3x9PT08AoqOjcXBwSHeM3LlzExUVZWxzfwAGjI8f1+bWrVvcuXOHrFmzPra+a9fiNRL8gl2/Hm/uEuQB6hPLov6wPOoTy6M+sSwvuz8yG7qfKgSPHj0auPdhtMjIyHTrnzYEDxkyhGPHjjFv3rynKeuFS001kJpqMHcZ/2nJyanmLkEeoD6xLOoPy6M+sTzqE8tiqf3xVCH48OHDz7sOhg4dyoYNG5gzZw758uUzLnd3dycpKYnY2FiT0eCYmBg8PDyMbfbt22eyv+joaACTNmnL7m/j7OycqVFgEREREfnvMPtMZYPBwNChQ1m7di0zZ86kcOHCJuu9vb1xcHBg27ZtxmUnT57k4sWL+Pr6AuDr68vRo0eJiYkxttm6dSvOzs6UKlXK2Gb79u0m+966datxHyIiIiJiPZ5qJHjXrl2PbVOlSpVM7SvtmsPffvst2bNnN87hzZEjB1mzZiVHjhy0aNGCkSNH4uLigrOzM8OHD8fPz88YYIOCgihVqhT9+vXjk08+ISoqinHjxtGmTRscHR0BCAkJYe7cuYwaNYoWLVqwfft2Vq5cyZQpU57mKRARERGRf7GnCsHt2rXDxsYGg+H/5sc+eNWEzN4xbv78+cZ93m/EiBHGG1kMGDAAW1tbevToYXKzjDR2dnZMnjyZ8PBwWrVqRbZs2WjWrBk9evQwtilcuDBTpkxhxIgRzJo1i3z58jF8+HBdI1hERETECj1VCF66dGm6ZTdv3mTz5s2sWbOGIUOGZHpfR44ceWybLFmyMHjwYJPg+6CCBQsybdq0R+4nICAgw9pFRERExLo8VQguU6ZMhssDAgLImjUrCxcupGrVqs9UmIiIiIjIi/LcPxjn7+/Pxo0bn/duRURERESem+cegtetW4erq+vz3q2IiIiIyHPzVNMhOnfunG5ZUlISp06d4tKlS3zyySfPXJiIiIiIyIvyVCE4Pj797e+yZMlCtWrVaNCgga64ICIiIiIW7alC8OzZs593HSIiIiIiL80zzwm+c+cOV69e5c6dO8+jHhERERGRF+6pRoIB/vzzTyZOnMihQ4cwGAzY2NhQtmxZevToQXBw8POsUURERETkuXqqkeB169bRtWtXHBwc6N+/P2PGjCEsLAxHR0e6dOnCunXrnnedIiIiIiLPzVONBE+cOJHGjRszevRok+Xt27enb9++TJw4kbp16z6XAkVEREREnrenGgk+efIkTZs2zXDdm2++ycmTJ5+lJhERERGRF+qpQrCLiwunTp3KcN2pU6dwcXF5pqJERERERF6kp5oO0ahRI8aOHUvWrFlp0KABOXPmJC4ujlWrVjFu3Dhatmz5vOsUEREREXlunioE9+nTh4sXL/L5558zaNAg7O3tSU5OxmAwUL9+fXr37v286xQREREReW6eKgQ7OjoyYcIEjhw5wu7du4mNjcXFxYVKlSrh5eX1vGsUEREREXmuMj0n+PTp0zRv3pyNGzcal3l5edGmTRu6dOlC69atuXz5Ms2bN+fcuXMvpFgRERERkech0yH4hx9+wMnJ6ZE3wggODiZ79uxMnz79uRQnIiIiIvIiZDoEb9myhRYtWjy2XYsWLdi8efMzFSUiIiIi8iJlOgRfuXKFwoULP7ZdoUKFuHLlyjMVJSIiIiLyImU6BGfPnp3r168/tt2NGzdwcnJ6pqJERERERF6kTIdgb29vVqxY8dh2v//+O97e3s9UlIiIiIjIi5TpENy6dWtWrlzJxIkTSUlJSbc+NTWViRMnsmrVKtq0afNcixQREREReZ4yfZ3gOnXq8MEHHzBx4kQWLFhAYGAgBQoUAODSpUts27aN6OhoOnbsSO3atV9YwSIiIiIiz+qJbpbRt29fqlSpwg8//MDq1atJTEwEIEuWLPj7+zN8+PBHXkJNRERERMQSPPEd44KDgwkODiYlJYUbN24A4Orqip2d3fOuTURERETkhXiq2yYD2NnZkTt37udZi4iIiIjIS5HpD8aJiIiIiPxXKASLiIiIiNVRCBYRERERq2P2ELxr1y46d+5MUFAQXl5erFu3zmR9//798fLyMvnq2LGjSZsbN27Qp08f/P39qVy5MgMGDCA+Pt6kzeHDh2ndujU+Pj4EBwczbdq0F35uIiIiImKZnvqDcc9LQkICXl5etGjRgm7dumXYpkaNGowYMcL42NHR0WR93759iYqKYsaMGSQlJTFgwAAGDRrEmDFjALh16xYdO3YkMDCQIUOGcPToUQYMGEDOnDlp1arVizs5EREREbFIZg/BaZdcexRHR0c8PDwyXHfixAk2bdrEzz//jI+PDwADBw6kU6dO9OvXj7x587Js2TKSkpKIiIjA0dGR0qVLc+jQIWbMmKEQLCIiImKFzB6CM2Pnzp0EBgaSM2dOqlatyscff0yuXLkA2Lt3Lzlz5jQGYIBq1apha2vLvn37qFevHpGRkVSuXNlkBDkoKIhp06Zx8+ZNXFxcMlWHra0NtrY2z/fkxIS9vdln6MgD1CeWRf1hedQnlkd9YlkstT8sPgTXqFGDevXqUahQIc6dO8fYsWP58MMPWbhwIXZ2dkRHR+Pm5mayjb29PS4uLkRFRQEQHR1NoUKFTNq4u7sb12U2BLu5ZcfGRiH4RcqVK7u5S5AHqE8si/rD8qhPLI/6xLJYan9YfAhu3Lix8f9pH4yrW7eucXT4Zbp2LV4jwS/Y9evxj28kL5X6xLKoPyyP+sTyqE8sy8vuj8yGbosPwQ8qXLgwuXLl4syZMwQGBuLu7s61a9dM2iQnJ3Pz5k3jPGJ3d3eio6NN2qQ9ThsRzozUVAOpqYZnPAN5lOTkVHOXIA9Qn1gW9YflUZ9YHvWJZbHU/rDMSRqPcPnyZW7cuGEMuH5+fsTGxnLgwAFjm+3bt5OamkqFChUA8PX1Zffu3SQlJRnbbN26leLFi2d6KoSIiIiI/HeYPQTHx8dz6NAhDh06BMD58+c5dOgQFy9eJD4+ni+//JLIyEjOnz/Ptm3b6Nq1K0WLFqVGjRoAlCxZkho1avD555+zb98+9uzZw7Bhw2jcuDF58+YFoEmTJjg4OPDZZ59x7NgxVqxYwaxZs3jvvffMdt4iIiIiYj5mnw5x4MAB3n33XePjtOsBN2vWjPDwcI4ePcrSpUuJi4sjT548VK9enZ49e5pc6WH06NEMGzaM9u3bY2trS/369Rk4cKBxfY4cOZg+fTpDhw6lefPm5MqVi65du+ryaCIiIiJWyuwhOCAggCNHjjx0/fTp0x+7D1dXV+ONMR6mTJkyzJs374nrExEREZH/HrNPhxARERERedkUgkVERETE6igEi4iIiIjVUQgWEREREaujECwiIiIiVkchWERERESsjkKwiIiIiFgdhWARERERsToKwSIiIiJidRSCRURERMTqKASLiIiIiNVRCBYRERERq6MQLCIiIiJWRyFYRERERKyOQrCIiIiIWB2FYBERERGxOgrBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhERERGroxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6igEi4iIiIjVUQgWEREREaujECwiIiIiVkchWERERESsjtlD8K5du+jcuTNBQUF4eXmxbt06k/UGg4FvvvmGoKAgKlSoQIcOHTh9+rRJmxs3btCnTx/8/f2pXLkyAwYMID4+3qTN4cOHad26NT4+PgQHBzNt2rQXfWoiIiIiYqHMHoITEhLw8vJi8ODBGa6fNm0as2fPJjw8nEWLFpEtWzY6duzI3bt3jW369u3L8ePHmTFjBpMnT2b37t0MGjTIuP7WrVt07NiRAgUK8Msvv9CvXz8mTpzIwoULX/j5iYiIiIjlsTd3AcHBwQQHB2e4zmAwMGvWLLp06ULdunUBGDVqFNWqVWPdunU0btyYEydOsGnTJn7++Wd8fHwAGDhwIJ06daJfv37kzZuXZcuWkZSUREREBI6OjpQuXZpDhw4xY8YMWrVq9dLOVUREREQsg9lD8KOcP3+eqKgoqlWrZlyWI0cOKlasyN69e2ncuDF79+4lZ86cxgAMUK1aNWxtbdm3bx/16tUjMjKSypUr4+joaGwTFBTEtGnTuHnzJi4uLpmqx9bWBltbm+d3gpKOvb3Z35yQB6hPLIv6w/KoTyyP+sSyWGp/WHQIjoqKAiB37twmy3Pnzk10dDQA0dHRuLm5may3t7fHxcXFuH10dDSFChUyaePu7m5cl9kQ7OaWHRsbheAXKVeu7OYuQR6gPrEs6g/Loz6xPOoTy2Kp/WHRIdjSXLsWr5HgF+z69fjHN5KXSn1iWdQflkd9YnnUJ5blZfdHZkO3RYdgDw8PAGJiYsiTJ49xeUxMDGXKlAHujeheu3bNZLvk5GRu3rxp3N7d3d04cpwm7XHaiHBmpKYaSE01PPmJSKYlJ6eauwR5gPrEsqg/LI/6xPKoTyyLpfaHZU7S+P8KFSqEh4cH27ZtMy67desWf//9N35+fgD4+fkRGxvLgQMHjG22b99OamoqFSpUAMDX15fdu3eTlJRkbLN161aKFy+e6akQIiIiIvLfYfYQHB8fz6FDhzh06BBw78Nwhw4d4uLFi9jY2PDuu+/y3XffsX79eo4cOUK/fv3IkyeP8WoRJUuWpEaNGnz++efs27ePPXv2MGzYMBo3bkzevHkBaNKkCQ4ODnz22WccO3aMFStWMGvWLN577z2znbeIiIiImI/Zp0McOHCAd9991/h4xIgRADRr1oyRI0fy4Ycfcvv2bQYNGkRsbCyVKlXi+++/J0uWLMZtRo8ezbBhw2jfvj22trbUr1+fgQMHGtfnyJGD6dOnM3ToUJo3b06uXLno2rWrLo8mIiIiYqXMHoIDAgI4cuTIQ9fb2NjQs2dPevbs+dA2rq6ujBkz5pHHKVOmDPPmzXvqOkVERETkv8Ps0yFERERERF42hWARERERsToKwSIiIiJidRSCRURERMTqKASLiIiIiNVRCBYRERERq6MQLCIiIiJWRyFYRERERKyOQrCIiIiIWB2FYBERERGxOgrBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhERERGroxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6igEi4iIiIjVUQgWEREREaujECwiIiIiVkchWERERESsjkKwiIiIiFgdhWARERERsToKwSIiIiJidRSCRURERMTqKASLiIiIiNWx+BA8YcIEvLy8TL4aNmxoXH/37l2GDBlCQEAAfn5+dO/enejoaJN9XLx4kU6dOlGxYkUCAwP58ssvSU5OftmnIiIiIiIWwt7cBWRG6dKlmTFjhvGxnZ2d8f8RERFs3LiRcePGkSNHDoYNG0a3bt1YsGABACkpKYSGhuLu7s6CBQu4evUqYWFhODg40Lt375d+LiIiIiJifhY/Egz3Qq+Hh4fxy83NDYC4uDgWL15M//79CQwMxNvbm4iICPbu3UtkZCQAmzdv5vjx43z11VeULVuW4OBgevbsydy5c0lMTDTjWYmIiIiIufwrRoLPnDlDUFAQWbJkwdfXlz59+lCgQAEOHDhAUlIS1apVM7YtWbIkBQoUIDIyEl9fXyIjI/H09MTd3d3YJigoiPDwcI4fP065cuUyXYetrQ22tjbP9dzElL39v+LvMquiPrEs6g/Loz6xPOoTy2Kp/WHxIbhChQqMGDGC4sWLExUVxaRJk2jTpg3Lly8nOjoaBwcHcubMabJN7ty5iYqKAiA6OtokAAPGx2ltMsvNLTs2NgrBL1KuXNnNXYI8QH1iWdQflkd9YnnUJ5bFUvvD4kNwcHCw8f9lypShYsWK1KpVi5UrV5I1a9aXWsu1a/EaCX7Brl+PN3cJ8gD1iWVRf1ge9YnlUZ9YlpfdH5kN3RYfgh+UM2dOihUrxtmzZ6lWrRpJSUnExsaajAbHxMTg4eEB3Bv13bdvn8k+0q4ekdYms1JTDaSmGp7xDORRkpNTzV2CPEB9YlnUH5ZHfWJ51CeWxVL7wzInaTxCfHw8586dw8PDA29vbxwcHNi2bZtx/cmTJ7l48SK+vr4A+Pr6cvToUWJiYoxttm7dirOzM6VKlXrZ5YuIiIiIBbD4keAvv/ySWrVqUaBAAa5evcqECROwtbXl9ddfJ0eOHLRo0YKRI0fi4uKCs7Mzw4cPx8/PzxiCg4KCKFWqFP369eOTTz4hKiqKcePG0aZNGxwdHc17ciIiIiJiFhYfgi9fvkzv3r25ceMGbm5uVKpUiUWLFhkvkzZgwABsbW3p0aMHiYmJBAUFMXjwYOP2dnZ2TJ48mfDwcFq1akW2bNlo1qwZPXr0MNcpiYiIiIiZWXwI/vrrrx+5PkuWLAwePNgk+D6oYMGCTJs27XmXJiIiIiL/Uv+6OcEiIiIiIs9KIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6igEi4iIiIjVUQgWEREREaujECwiIiIiVkchWERERESsjkKwiIiIiFgdhWARERERsToKwSIiIiJidRSCRURERMTqKASLiIiIiNVRCBYRERERq6MQLCIiIiJWRyFYRERERKyOQrCIiIiIWB2FYBERERGxOgrBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhERERGroxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnUUgkVERETE6lhdCJ47dy61a9fGx8eHt99+m3379pm7JBERERF5yawqBK9YsYIRI0bw0UcfsWTJEsqUKUPHjh2JiYkxd2kiIiIi8hJZVQieMWMGLVu2pEWLFpQqVYohQ4aQNWtWFi9ebO7SREREROQlsjd3AS9LYmIiBw8eJDQ01LjM1taWatWqsXfv3kztw9bWBltbmxdVogD29lb1d9m/gvrEsqg/LI/6xPKoTyyLpfaHjcFgMJi7iJfhypUr1KxZkwULFuDn52dcPmrUKHbt2sVPP/1kxupERERE5GWyzGguIiIiIvICWU0IzpUrF3Z2duk+BBcTE4O7u7uZqhIRERERc7CaEOzo6Ej58uXZtm2bcVlqairbtm0zmR4hIiIiIv99VvPBOID33nuPsLAwvL29qVChAjNnzuT27ds0b97c3KWJiIiIyEtkVSG4UaNGXLt2jfHjxxMVFUXZsmX5/vvvNR1CRERExMpYzdUhRERERETSWM2cYBERERGRNArBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhNz586ldu3a+Pj48Pbbb7Nv3z5zl2TVdu3aRefOnQkKCsLLy4t169aZuySrNmXKFFq0aIGfnx+BgYF07dqVkydPmrssqzVv3jyaNGmCv78//v7+tGrVio0bN5q7LLnP1KlT8fLy4osvvjB3KVZrwoQJeHl5mXw1bNjQ3GVZBIVgMVqxYgUjRozgo48+YsmSJZQpU4aOHTumu8uevDwJCQl4eXkxePBgc5ciwM6dO2nTpg2LFi1ixowZJCcn07FjRxISEsxdmlXKly8fffv25ZdffmHx4sVUrVqVjz76iGPHjpm7NAH27dvHggUL8PLyMncpVq906dJs3rzZ+DVv3jxzl2QRrOo6wfJoM2bMoGXLlrRo0QKAIUOGsGHDBhYvXkynTp3MXJ11Cg4OJjg42NxlyP83ffp0k8cjR44kMDCQgwcPUqVKFTNVZb1q165t8rhXr17Mnz+fyMhISpcubaaqBCA+Pp5PPvmE4cOH891335m7HKtnZ2eHh4eHucuwOBoJFgASExM5ePAg1apVMy6ztbWlWrVq7N2714yViViuuLg4AFxcXMxciaSkpPD777+TkJCAn5+fucuxekOHDiU4ONjkd4qYz5kzZwgKCqJOnTr06dOHixcvmrski6CRYAHg+vXrpKSkkDt3bpPluXPn1pxHkQykpqYSERGBv78/np6e5i7Hah05coSQkBDu3r2Lk5MTkyZNolSpUuYuy6r9/vvv/PPPP/z888/mLkWAChUqMGLECIoXL05UVBSTJk2iTZs2LF++HGdnZ3OXZ1YKwSIiT2HIkCEcO3ZMc+vMrHjx4ixdupS4uDhWr15NWFgYc+bMURA2k0uXLvHFF1/www8/kCVLFnOXI2Aypa5MmTJUrFiRWrVqsXLlSt5++20zVmZ+CsECQK5cubCzs0v3IbiYmBjc3d3NVJWIZRo6dCgbNmxgzpw55MuXz9zlWDVHR0eKFi0KgLe3N/v372fWrFkMHTrUzJVZp4MHDxITE0Pz5s2Ny1JSUti1axdz585l//792NnZmbFCyZkzJ8WKFePs2bPmLsXsFIIFuPeLpHz58mzbto26desC997u3bZtG23btjVzdSKWwWAwMGzYMNauXcvs2bMpXLiwuUuSB6SmppKYmGjuMqxW1apVWb58ucmyTz/9lBIlSvDhhx8qAFuA+Ph4zp07pw/KoRAs93nvvfcICwvD29ubChUqMHPmTG7fvm3yF728XPHx8SZ/rZ8/f55Dhw7h4uJCgQIFzFiZdRoyZAi//fYb3377LdmzZycqKgqAHDlykDVrVjNXZ33GjBlDzZo1yZ8/P/Hx8fz222/s3Lkz3VU85OVxdnZON0feyckJV1dXzZ03ky+//JJatWpRoEABrl69yoQJE7C1teX11183d2lmpxAsRo0aNeLatWuMHz+eqKgoypYty/fff6/pEGZ04MAB3n33XePjESNGANCsWTNGjhxprrKs1vz58wFo166dyfIRI0boj0UziImJISwsjKtXr5IjRw68vLyYPn061atXN3dpIhbj8uXL9O7dmxs3buDm5kalSpVYtGgRbm5u5i7N7GwMBoPB3EWIiIiIiLxMuk6wiIiIiFgdhWARERERsToKwSIiIiJidRSCRURERMTqKASLiIiIiNVRCBYRERERq6MQLCIiIiJWRyFYRERERKyOQrCIiJktW7aMkJAQ/Pz88PPzo1WrVixduvSp9jVhwgT++uuv51ugiMh/kG6bLCJiRsOGDWPu3Lm0aNGCrl27YmNjw+rVq+nfvz/79+/n888/f6L9TZw4EScnJ/z9/V9QxSIi/w0KwSIiZrJ+/XrmzJlDt27d6N69u3F5jRo1yJMnD5MmTaJ69erUrl3bjFWKiPw3aTqEiIiZzJw5ExcXF95///106zp27IiLiwszZ84EoF27doSGhpq0OXToEF5eXuzYsQMALy8vAEaNGoWXl5fJutTUVGbMmMFrr72Gt7c31atXp0ePHsTFxRn3t2vXLkJCQqhQoQIBAQF8+umn3Lhxw7j+/PnzeHl5sXTpUgYNGkTlypUJDAxkxowZAPz+++80aNAAf39/unXrRmxsrEm9sbGxhIeHExQUhLe3N82bN2fz5s3P+CyKiDwdjQSLiJhBcnIye/fu5dVXXyV79uzp1mfPnp2AgAA2btxIcnJypva5cOFCWrVqRbt27Xj99dcBKFWqFHBv2sXChQtp37491atXJz4+ng0bNpCQkECOHDk4cOAA7733HgEBAXzzzTdER0czZswYjh8/zoIFC7CzszMeZ9y4cdSvX59vvvmGdevWMXLkSK5du8bOnTv55JNPuHXrFsOHD+err75i2LBhACQmJvLee+8RExPDxx9/TN68eVm2bBmhoaH88ssvxgAvIvKyKASLiJjB9evXSUxMJH/+/A9tkz9/fu7evWsyGvsovr6+xu3S/g9w6tQp5s+fT69evUxGkxs0aGD8/+TJk/Hw8GDy5Mk4ODgY99OxY0c2btxoMiXD19eXAQMGAFC1alXWrFnDnDlz+OOPP8iVKxcAR44c4eeffzaG4OXLl3P48GF+/fVXYzCvUaMGZ86c4dtvv+Wbb77J1DmKiDwvmg4hIvIft337dgwGA2+99dZD2+zevZs6deoYAzBAUFAQOXPmZM+ePSZtq1evbvy/nZ0dhQsXpkyZMsYADFCsWDFiY2OJj48HYMuWLXh6elKsWDGSk5ONX9WqVWP//v3P61RFRDJNI8EiImaQK1cuHB0duXTp0kPbXLp0iSxZsuDq6vpMx7px4wb29vbkzp37oW1iY2MzXJ87d25u3rxpsixHjhwmjx0cHHByckq3DODu3btkz56d69ev888//1C+fPl0x7h/qoWIyMuiECwiYgb29vb4+fmxc+dOEhIS0oXIhIQEdu7ciZ+fH/b29jg6OpKUlGTS5sFw+jCurq4kJycTExPz0CDs4uJCTExMuuUxMTG4uLhk8qwezsXFBS8vL7744otn3peIyPOg6RAiImbSvn17bty4wQ8//JBu3Q8//MCNGzdo3749APny5ePUqVMYDAZjmy1btqTbzsHBgbt375osq1q1KjY2NixevPihtVSqVIn169ebfAhvy5YtxMbGUqlSpSc+twdVq1aNc+fOkSdPHnx8fNJ9iYi8bBoJFhExkzp16tC2bVsmTpzI5cuXadiwIQBr1qxh0aJFtG3b1viBtAYNGhg/aFa3bl3++usvVq9enW6fJUqUYP369VSuXJls2bJRvHhxihcvTkhICN988w03b94kMDCQO3fusGHDBrp3707evHnp3LkzISEhhIaG0q5dO+PVISpUqEBwcPAzn2vTpk1ZsGAB7777Lu+//z7FihUjLi6Of/75h6SkJPr06fPMxxAReRIKwSIiZvT5559TsWJF5s2bZ7xhhqenJyNHjqRp06bGdjVr1uSTTz5hzpw5LFmyhJo1azJkyBA6dOhgsr9BgwYRERHBhx9+yJ07d5g1axYBAQEMGjSIQoUK8dNPPzFz5kxcXV2pUqWK8fJs3t7e/PDDD4wdO5bu3bvj5ORE7dq1CQsLey5zdh0dHZk1axYTJkxg8uTJREVF4erqSrly5WjduvUz719E5EnZGO5/b01ERERExApoTrCIiIiIWB2FYBERERGxOgrBIiIiImJ1FIJFRERExOooBIuIiIiI1VEIFhERERGroxAsIiIiIlZHIVhERERErI5CsIiIiIhYHYVgEREREbE6CsEiIiIiYnX+H6zT4jAczrKUAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "expected_counts = probabilities * n_trials\n",
     "fig, ax = plt.subplots(figsize=(8, 4))\n",
@@ -172,10 +208,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "5194b61d",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-28T01:13:00.324672Z",
+     "iopub.status.busy": "2025-09-28T01:13:00.324298Z",
+     "iopub.status.idle": "2025-09-28T01:13:00.334224Z",
+     "shell.execute_reply": "2025-09-28T01:13:00.333186Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([ 0.0848,  0.0317, -0.0358, -0.0079, -0.001 , -0.0718])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "baseline_prob = np.full(n_outcomes, 1.0 / n_outcomes)\n",
     "empirical_prob = counts.values / n_trials\n",
@@ -208,7 +262,20 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/src/wamecu/__init__.py
+++ b/src/wamecu/__init__.py
@@ -1,0 +1,11 @@
+"""Core utilities for WAMECU experiments."""
+
+from .simulation import wamecu_probabilities, simulate_draws
+from .anomaly import chi_square_statistic, entropy_gap
+
+__all__ = [
+    "wamecu_probabilities",
+    "simulate_draws",
+    "chi_square_statistic",
+    "entropy_gap",
+]

--- a/src/wamecu/anomaly.py
+++ b/src/wamecu/anomaly.py
@@ -1,0 +1,39 @@
+"""Statistical diagnostics for WAMECU simulations."""
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import chi2
+
+
+def chi_square_statistic(observed: np.ndarray, expected: np.ndarray) -> tuple[float, float]:
+    """Return the chi-square statistic and p-value for observed vs. expected counts."""
+    observed = np.asarray(observed, dtype=float)
+    expected = np.asarray(expected, dtype=float)
+    if observed.shape != expected.shape:
+        raise ValueError("observed and expected must have the same shape")
+    if np.any(expected <= 0):
+        raise ValueError("expected counts must be positive")
+
+    statistic = np.sum((observed - expected) ** 2 / expected)
+    dof = observed.size - 1
+    p_value = 1 - chi2.cdf(statistic, df=dof)
+    return float(statistic), float(p_value)
+
+
+def entropy_gap(empirical_prob: np.ndarray, baseline_prob: np.ndarray) -> float:
+    """Compute the Shannon entropy gap between empirical and baseline distributions."""
+    empirical_prob = np.asarray(empirical_prob, dtype=float)
+    baseline_prob = np.asarray(baseline_prob, dtype=float)
+    if empirical_prob.shape != baseline_prob.shape:
+        raise ValueError("probability vectors must have matching shape")
+    if not np.isclose(empirical_prob.sum(), 1.0):
+        raise ValueError("empirical_prob must sum to 1")
+    if not np.isclose(baseline_prob.sum(), 1.0):
+        raise ValueError("baseline_prob must sum to 1")
+
+    # avoid log(0); only include terms where probability > 0
+    mask_empirical = empirical_prob > 0
+    mask_baseline = baseline_prob > 0
+    entropy_empirical = -np.sum(empirical_prob[mask_empirical] * np.log2(empirical_prob[mask_empirical]))
+    entropy_baseline = -np.sum(baseline_prob[mask_baseline] * np.log2(baseline_prob[mask_baseline]))
+    return float(entropy_empirical - entropy_baseline)

--- a/src/wamecu/simulation.py
+++ b/src/wamecu/simulation.py
@@ -1,0 +1,37 @@
+"""Simulation helpers implementing the WAMECU probability law."""
+from __future__ import annotations
+
+import math
+from typing import Iterable
+
+import numpy as np
+
+
+def wamecu_probabilities(n_outcomes: int, beta: Iterable[float]) -> np.ndarray:
+    """Convert bias coefficients into a normalized probability distribution."""
+    beta_array = np.asarray(list(beta), dtype=float)
+    if beta_array.size != n_outcomes:
+        raise ValueError("beta vector must match number of outcomes")
+
+    base = np.full(n_outcomes, 1.0 / n_outcomes)
+    adjusted = base * (1 + beta_array)
+
+    if np.any(adjusted < 0):
+        raise ValueError("bias coefficients yield negative probabilities")
+
+    total = adjusted.sum()
+    if total <= 0:
+        raise ValueError("bias coefficients collapse the probability mass")
+
+    if not math.isclose(total, 1.0):
+        adjusted = adjusted / total
+    return adjusted
+
+
+def simulate_draws(probabilities: np.ndarray, n_trials: int, seed: int | None = None) -> np.ndarray:
+    """Simulate draws from a categorical distribution defined by ``probabilities``."""
+    if n_trials <= 0:
+        raise ValueError("n_trials must be positive")
+    rng = np.random.default_rng(seed)
+    support = np.arange(probabilities.size)
+    return rng.choice(support, size=n_trials, p=probabilities)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+project_root = Path(__file__).resolve().parents[1]
+src_path = project_root / "src"
+if str(src_path) not in sys.path:
+    sys.path.insert(0, str(src_path))

--- a/tests/test_anomaly.py
+++ b/tests/test_anomaly.py
@@ -1,0 +1,24 @@
+import numpy as np
+import pytest
+
+from wamecu import chi_square_statistic, entropy_gap
+
+
+def test_chi_square_detects_bias():
+    observed = np.array([60, 25, 15])
+    expected = np.array([100 / 3, 100 / 3, 100 / 3])
+    statistic, p_value = chi_square_statistic(observed, expected)
+    assert statistic > 0
+    assert p_value < 0.05
+
+
+def test_entropy_gap_signals_concentration():
+    empirical = np.array([0.6, 0.3, 0.1])
+    baseline = np.full(3, 1 / 3)
+    gap = entropy_gap(empirical, baseline)
+    assert gap < 0
+
+
+def test_entropy_gap_validates_inputs():
+    with pytest.raises(ValueError):
+        entropy_gap(np.array([0.5, 0.5]), np.array([0.4, 0.4]))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pytest
+
+from wamecu import simulate_draws, wamecu_probabilities
+
+
+def test_wamecu_probabilities_normalize():
+    beta = [0.1, -0.05, -0.05]
+    probs = wamecu_probabilities(3, beta)
+    assert pytest.approx(1.0) == probs.sum()
+    assert np.all(probs >= 0)
+
+
+def test_simulate_draws_reproducible():
+    probs = np.array([0.2, 0.5, 0.3])
+    draws_one = simulate_draws(probs, 1000, seed=7)
+    draws_two = simulate_draws(probs, 1000, seed=7)
+    assert np.array_equal(draws_one, draws_two)
+
+
+def test_wamecu_probabilities_mismatch_shape():
+    with pytest.raises(ValueError):
+        wamecu_probabilities(2, [0.1, 0.2, 0.3])


### PR DESCRIPTION
## Abstract
Executed 20k synthetic draws under a biased WAMECU coefficient vector and computed chi-square and entropy metrics that both flag statistically significant skew relative to a uniform baseline. Visual diagnostics include the observed vs. expected bar chart and the chi-square p-value (9.0e-10), demonstrating how the framework surfaces bias.

## Summary
- Refactored reusable probability and sampling helpers into `src/wamecu` and added chi-square plus entropy diagnostics for anomaly detection workflows.
- Updated the original prototype notebook to import the shared helpers and remain reproducible under the new layout.
- Authored a dedicated anomaly-detection notebook that visualizes deviations and reports statistical tests triggered by WAMECU-driven bias.
- Added pytest coverage for the simulation and anomaly routines to guard against regressions.

## Testing
- `pytest`
- `jupyter nbconvert --to notebook --execute --inplace notebooks/WAMECU_prototype.ipynb`
- `jupyter nbconvert --to notebook --execute --inplace notebooks/WAMECU_anomaly_detection.ipynb`


------
https://chatgpt.com/codex/tasks/task_b_68d88a897a4083208cebc4e999d3e4ab